### PR TITLE
Pinned all dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,26 +10,26 @@
     "url": "https://github.com/greenkeeperio/support/issues"
   },
   "dependencies": {
-    "abbrev": "^1.0.7",
-    "ansi": "^0.3.0",
-    "char-spinner": "^1.0.1",
+    "abbrev": "1.0.7",
+    "ansi": "0.3.0",
+    "char-spinner": "1.0.1",
     "github-slug": "0.0.2",
-    "hide-secrets": "^1.0.0",
-    "lodash": "^3.10.1",
-    "node-emoji": "^1.0.3",
-    "nopt": "^3.0.3",
-    "npmlog": "^1.2.1",
+    "hide-secrets": "1.0.0",
+    "lodash": "3.10.1",
+    "node-emoji": "1.0.3",
+    "nopt": "3.0.4",
+    "npmlog": "1.2.1",
     "open": "0.0.5",
-    "os-homedir": "^1.0.1",
-    "random-string": "^0.1.2",
-    "request": "^2.60.0",
-    "update-notifier": "^0.5.0"
+    "os-homedir": "1.0.1",
+    "random-string": "0.1.2",
+    "request": "2.64.0",
+    "update-notifier": "0.5.0"
   },
   "devDependencies": {
-    "nyc": "^3.1.0",
-    "semantic-release": "^4.3.5",
-    "standard": "^5.0.2",
-    "tap": "^1.3.2"
+    "nyc": "3.2.2",
+    "semantic-release": "4.3.5",
+    "standard": "5.3.1",
+    "tap": "1.4.1"
   },
   "homepage": "http://greenkeeper.io/",
   "license": "UNLICENSED",


### PR DESCRIPTION
:wave: Hello!

We’re all trying to keep our software up to date, yet stable at the same time.

This is the first in a series of automatic PRs to help you achieve this goal. It pins all of the dependencies in your `package.json`, so you have complete control over the exact state of your software.

From now on you’ll receive PRs whenever one of your dependencies updates – in real time. This way you get all the benefits of up-to-date dependencies, while having them pinned at the same time. This means:

- No more surprises because some of your dependencies didn’t follow [SemVer](http://semver.org/). Your software is always in a state you know about, regardless of _when_ someone does `$ npm install`.
- If you have continuous integration set up for this repo, it’ll run automatically. Ideally, it will pass and you'll stay up to date with the press of a button. If the updated dependency _does_ break your software, it won’t affect your users, because their dependencies are still pinned to the working state.
- You can immediately identify which dependency updates break your software, because each one is tested in isolation. You’ll also have a branch ready to work on, so adapting to new APIs is way faster.

Merge this PR and you’ll have up-to-date software without the headaches :sparkles:

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>