### PR TITLE
The Intercom chat isn't being used anymore

### DIFF
--- a/src/support.js
+++ b/src/support.js
@@ -10,7 +10,7 @@ module.exports = function (flags) {
     process.exit(1)
   }
 
-  log.info('support', 'Opening Intercom chat in browser')
+  log.info('support', 'Opening GitHub issues')
 
   open(flags.api + 'support?access_token=' + flags.token)
 }


### PR DESCRIPTION
Therefore I'd like to replace the message that pops up when running `greenkeeper support`.