### PR TITLE
feat(alias): Add init alias for enable

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -36,6 +36,7 @@ exports.aliases = {
   signup: 'login',
   signin: 'login',
   signout: 'logout',
+  init: 'enable',
   on: 'enable',
   off: 'disable',
   access: 'organization-access',


### PR DESCRIPTION
This allows people to `greenkeeper init`, instead of `greenkeeper enable`, as discussed in semantic-release/cli#73