### PR TITLE
feat(alias): Alias status to info

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -37,6 +37,7 @@ exports.aliases = {
   signup: 'login',
   signin: 'login',
   signout: 'logout',
+  status: 'info',
   init: 'enable',
   on: 'enable',
   off: 'disable',


### PR DESCRIPTION
Hey :)

I was intuitively looking for a `status` command. So maybe aliasing it to `info` would be nice.

Best,
Finn