### PR TITLE
show URL if fail to open

### DIFF
--- a/src/login.js
+++ b/src/login.js
@@ -42,14 +42,9 @@ module.exports = function (flags) {
   var url = flags.api + 'login?id=' + id + (flags['private'] ? '&private=true' : '')
 
   log.verbose('login', 'Open ' + url)
-  var openResult = open(url)
-
-  var tmCheck = setInterval(function () {
-    if (openResult.exitCode !== null) {
-      clearInterval(tmCheck)
-      if (openResult.exitCode !== 0) {
-        console.log('Login from this URL:', url)
-      }
+  open(url, function (err, stdout, stderr) {
+    if (err) {
+      console.log('Login from this URL:', url)
     }
-  }, 100)
+  })
 }

--- a/src/login.js
+++ b/src/login.js
@@ -42,5 +42,14 @@ module.exports = function (flags) {
   var url = flags.api + 'login?id=' + id + (flags['private'] ? '&private=true' : '')
 
   log.verbose('login', 'Open ' + url)
-  open(url)
+  var openResult = open(url)
+
+  var tmCheck = setInterval(function () {
+    if (openResult.exitCode !== null) {
+      clearInterval(tmCheck)
+      if (openResult.exitCode !== 0) {
+        console.log('Login from this URL:', url)
+      }
+    }
+  }, 100)
 }


### PR DESCRIPTION
Hi. I saw the same problem as #69. I'd like to see the URL even if I don't know the option `--verbose`.

```
$ greenkeeper login
                        oooo
                        `888
             .ooooooooo  888  ooooo
            8888' `8888  888 .88P'
            8888   8888  8888888.       g r e e n k e e p e r . i o
            `888bod88P'  888 `888b.
             `Yooooooo. o888o o8888o
                  `Y88b
            d88P   d888
            `Y8888888P'


Login from this URL: https://api.greenkeeper.io/login?id=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
```