### PR TITLE
feat: Show a warning if the .travis.yml excludes greenkeeper branches

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "github-slug": "^2.0.0",
     "hide-secrets": "^1.0.0",
     "inquirer": "^0.12.0",
+    "js-yaml": "3.6.1",
     "json-preserve-indent": "^1.1.1",
     "lodash": "^4.0.0",
     "nerf-dart": "^1.0.0",


### PR DESCRIPTION
This will check for the `branches.only` key in the `.travis.yml`. If it's present and there is no key matching the branchPrefix, it will show the following warning:

```
🌴  WARN enable Your .travis.yml is configured to only run for specific branches.
🌴  WARN enable For Greenkeeper to work you need to whitelist the Greenkeeper branches.
🌴  WARN enable Add this rule to branches.only in your .travis.yml:
🌴  WARN enable    - /^greenkeeper-.*$/
```

closes #222