### PR TITLE
feat(info): Show list of open PRs, closes #150

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "js-yaml": "3.6.1",
     "json-preserve-indent": "^1.1.1",
     "lodash": "^4.0.0",
+    "moment": "2.14.1",
     "nerf-dart": "^1.0.0",
     "node-emoji": "^1.0.4",
     "npm-registry-client": "^7.1.0",

--- a/src/info.js
+++ b/src/info.js
@@ -1,6 +1,7 @@
 var chalk = require('chalk')
 var log = require('npmlog')
 var request = require('request')
+var moment = require('moment')
 
 var story = require('./lib/story').info
 
@@ -27,7 +28,7 @@ module.exports = function (flags) {
     log.http('info', 'Sending request')
     request({
       method: 'GET',
-      url: flags.api + 'packages/' + slug,
+      url: flags.api + 'packages/' + slug + '?include_branches=true',
       json: true,
       headers: {
         Authorization: 'Bearer ' + flags.token
@@ -64,6 +65,15 @@ module.exports = function (flags) {
       }
 
       console.log('greenkeeper is enabled for this repository')
+      var prs = data.branches
+        .filter(function (branch) {
+          return branch.pr && branch.pr.state === 'open'
+        })
+      if (prs.length > 0) console.log('Open pull requests: ')
+      prs.forEach(function (branch) {
+        console.log('- ' + chalk.green('#' + branch.pr.number) + ' ' + branch.dependency + '@' + branch.version + ' ' + chalk.grey(moment(branch.created_at).fromNow()))
+      })
+      if (prs.length > 0) console.log('Older pull requests might not be shown.')
     })
   }
 }


### PR DESCRIPTION
This adds listing open PRs of a repository to the `gk info` command.

Example output (will be colored):
```
greenkeeper is enabled for this repository
Open pull requests:
- #251 npmlog@4.0.0 a month ago
- #246 inquirer@1.1.2 a month ago
Older pull requests might not be shown.
```