### PR TITLE
chore(package): update npm-registry-client to 8.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2,7 +2,7 @@
   "name": "@greenkeeper/jobs",
   "version": "0.0.0-development",
   "lockfileVersion": 1,
-  "packageIntegrity": "sha512-KCCb7RXuxVczAPO9/MeA4GLRD844TyXC7zOVUw+sWVHtx4sJgeuVPt/M9nOJar7edc9hSM/Nj2btXA8VCEqcXQ==",
+  "packageIntegrity": "sha512-XfAAZb/MpRbdx4lTLcS+HjNGcOSAh3xh3Xc5WUzXxwcG+HOcIi5dDbHYd990jr+cWkJY2nLb+KFr6XoT0mXZiQ==",
   "dependencies": {
     "acorn": {
       "version": "5.0.3",
@@ -2582,9 +2582,9 @@
       "integrity": "sha1-WTMD/eqF98Qid18X+et2cPaA4+w="
     },
     "npm-registry-client": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-7.5.0.tgz",
-      "integrity": "sha1-D23W5dEUJM+pn85bkw/q8JtPfwQ="
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-8.3.0.tgz",
+      "integrity": "sha512-rBFLIisl55sq77Bf189ptxaFGEkTNcZpvR7UFZI7bmG/wYD2hY/2Ix1Ss26aOLSbyctwHuUPZ3tJRSYnkmMQkg=="
     },
     "npmlog": {
       "version": "4.1.0",
@@ -4655,6 +4655,11 @@
           "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         }
       }
+    },
+    "ssri": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-4.1.2.tgz",
+      "integrity": "sha1-PTxptJDQsQd3Kpv4GIHziuBx8ks="
     },
     "stack-utils": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "json-in-place": "^1.0.1",
     "jsonwebtoken": "^7.1.9",
     "lodash": "^4.16.1",
-    "npm-registry-client": "^7.2.1",
+    "npm-registry-client": "^8.3.0",
     "pouchdb-http": "^6.0.2",
     "pouchdb-mapreduce": "^6.0.5",
     "pouchdb-upsert": "^2.2.0",


### PR DESCRIPTION
This a Greenkeeper PR that we lost while moving the repo.
We need to look into how the newly minified registry responses work with Greenkeeper before merging.