### PR TITLE
chore(package): update github to 9.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2,7 +2,7 @@
   "name": "@greenkeeper/jobs",
   "version": "0.0.0-development",
   "lockfileVersion": 1,
-  "packageIntegrity": "sha512-sI6q2ZwfBUDNhHmRQGX//boI67PgY7GiwHUKP/FB1OQg4YYuxmCWwQlYNyAAcCt0sLljPKkjpCjTI1o5EGPnKg==",
+  "packageIntegrity": "sha512-mTzjPDcxmZp31JV2nkjBdOK6Z2DwaCpgTeg/VCabTJ6hv00OWrcr71WaGQsG3t8tB4KSvd//fjen0gXx7R5LGw==",
   "dependencies": {
     "acorn": {
       "version": "5.0.3",
@@ -1788,9 +1788,9 @@
       }
     },
     "github": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/github/-/github-8.2.1.tgz",
-      "integrity": "sha1-YWsiEfvNHMhjFmmu1nZT5i61OBY="
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/github/-/github-9.2.0.tgz",
+      "integrity": "sha1-iohtxA3WNjZwfcr5nfPfJsWfFvw="
     },
     "github-url-from-git": {
       "version": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "couchdb-bootstrap": "^1.14.0",
     "envalid": "^3.0.0",
     "escape-string-regexp": "^1.0.5",
-    "github": "^8.2.1",
+    "github": "^9.2.0",
     "github-url-from-git": "^1.4.0",
     "hot-shots": "^4.3.0",
     "js-yaml": "^3.7.0",


### PR DESCRIPTION
This a Greenkeeper PR that we lost while moving the repo.
Since 9.0.0 all methods return differently formatted responses, so we need to update everything.
If someone would be willing to update this, that would be cool 🙏 