### PR TITLE
fix: update repo doc files on every push

### DIFF
--- a/lib/repository-docs.js
+++ b/lib/repository-docs.js
@@ -4,7 +4,6 @@ const crypto = require('crypto')
 const updatedAt = require('./updated-at')
 
 module.exports = {
-  readPackageJson,
   createDocs,
   updateRepoDoc
 }
@@ -18,7 +17,6 @@ async function updateRepoDoc (github, doc) {
     'yarn.lock'
   ]
   const files = await getFiles(github, fullName, fileList)
-
   doc.files = _.mapValues(files, content => !!content)
   const pkg = formatPackageJson(files['package.json'])
   if (!pkg) {
@@ -47,17 +45,6 @@ function formatPackageJson (content) {
     'maintainers',
     'author'
   ])
-}
-
-async function readPackageJson (github, fullName) {
-  const [owner, repo] = fullName.split('/')
-  const file = await getGithubFile(github, {
-    path: 'package.json',
-    repo,
-    owner
-  })
-  if (!file.content) return
-  return formatPackageJson(file.content)
 }
 
 function createDocs ({ repositories, accountId }) {

--- a/test/lib/repository-docs.js
+++ b/test/lib/repository-docs.js
@@ -3,46 +3,7 @@ const { test } = require('tap')
 
 const Github = require('../../lib/github')
 
-const { createDocs, updateRepoDoc, readPackageJson } = require(
-  '../../lib/repository-docs'
-)
-
-test('readPackageJson', async t => {
-  nock('https://api.github.com', {
-    reqheaders: { Authorization: 'token secret' }
-  })
-    .get('/repos/finnp/test/contents/package.json')
-    .reply(200, {
-      type: 'file',
-      path: 'package.json',
-      content: Buffer.from(JSON.stringify({ name: 'testing' }))
-        .toString('base64')
-    })
-
-  const github = Github()
-  github.authenticate({
-    type: 'token',
-    token: 'secret'
-  })
-  const pkg = await readPackageJson(github, 'finnp/test')
-  t.is(pkg.name, 'testing')
-  t.end()
-})
-
-test('readPackageJson no file', async t => {
-  nock('https://api.github.com', {
-    reqheaders: { Authorization: 'token secret' }
-  })
-
-  const github = Github()
-  github.authenticate({
-    type: 'token',
-    token: 'secret'
-  })
-  const pkg = await readPackageJson(github, 'finnp/test2')
-  t.notOk(pkg)
-  t.end()
-})
+const { createDocs, updateRepoDoc } = require('../../lib/repository-docs')
 
 test('updateRepoDoc with package.json', async t => {
   nock('https://api.github.com', {


### PR DESCRIPTION
Before we only synced the existing files on the initial branch. We need to make sure to sync the lock files on every push. This will result in a few more requests to GitHub, so we should check if we optimize this a bit more in the future.