### PR TITLE
Feat: user created initial pr

### DIFF
--- a/jobs/github-event/pull_request/opened.js
+++ b/jobs/github-event/pull_request/opened.js
@@ -1,0 +1,33 @@
+const dbs = require('../../../lib/dbs')
+const getConfig = require('../../../lib/get-config')
+
+module.exports = async function (data) {
+  const { repositories } = await dbs()
+  const { pull_request: pullRequest, repository } = data
+  const repositoryId = String(repository.id)
+  const prDocId = `${repositoryId}:pr:${pullRequest.id}`
+  const repoDoc = await repositories.get(repositoryId)
+  const config = getConfig(repoDoc)
+
+  const wasCreatedByGreenkeeper = pullRequest.user.type === 'Bot' && pullRequest.user.login.substr(0, 11) === 'greenkeeper'
+  if (wasCreatedByGreenkeeper) return
+
+  const isInitialGreenkeeperBranch = pullRequest.head.ref === `${config.branchPrefix}initial`
+  if (!isInitialGreenkeeperBranch) return
+
+  await repositories.put(
+    {
+      _id: prDocId,
+      repositoryId,
+      accountId: repository.owner.id,
+      type: 'pr',
+      initial: true,
+      number: pullRequest.number,
+      head: pullRequest.head.ref,
+      state: pullRequest.state,
+      merged: pullRequest.merged,
+      createdAt: new Date().toJSON(),
+      createdByUser: true
+    }
+  )
+}

--- a/jobs/github-event/pull_request/opened.js
+++ b/jobs/github-event/pull_request/opened.js
@@ -1,12 +1,15 @@
 const dbs = require('../../../lib/dbs')
 const getConfig = require('../../../lib/get-config')
+const { hasBilling } = require('../../../lib/payments')
+const githubQueue = require('../../../lib/github-queue')
 
 module.exports = async function (data) {
   const { repositories } = await dbs()
-  const { pull_request: pullRequest, repository } = data
+  const { pull_request: pullRequest, repository, installation } = data
   const repositoryId = String(repository.id)
   const prDocId = `${repositoryId}:pr:${pullRequest.id}`
   const repoDoc = await repositories.get(repositoryId)
+  const [owner, repo] = repository.full_name.split('/')
   const config = getConfig(repoDoc)
 
   const wasCreatedByGreenkeeper = pullRequest.user.type === 'Bot' && pullRequest.user.login.substr(0, 11) === 'greenkeeper'
@@ -30,4 +33,18 @@ module.exports = async function (data) {
       createdByUser: true
     }
   )
+  const ghqueue = githubQueue(installation.id)
+
+  const accountHasBilling = await hasBilling(repository.owner.id)
+  if (repoDoc.private && !accountHasBilling) {
+    await ghqueue.write(github => github.repos.createStatus({
+      owner,
+      repo,
+      sha: pullRequest.head.sha,
+      state: 'pending',
+      context: 'greenkeeper/payment',
+      description: 'Payment required, merging will have no effect',
+      target_url: 'https://account.greenkeeper.io/'
+    }))
+  }
 }

--- a/jobs/github-event/status.js
+++ b/jobs/github-event/status.js
@@ -37,6 +37,30 @@ module.exports = async function ({ state, sha, repository, installation }) {
   if (branchDoc.state === combined.state) return
 
   if (branchDoc.initial) {
+    const result = await repositories.allDocs({
+      include_docs: true,
+      descending: true,
+      startkey: `${repository.id}:pr:\uffff`,
+      endkey: `${repository.id}:pr:`
+    })
+    const initialRow = result.rows.find((row) => {
+      return row.doc.initial && row.doc.createdByUser
+    })
+
+    if (initialRow) {
+      return {
+        data: {
+          name: 'create-initial-pr-comment',
+          accountId,
+          branchDoc,
+          prDocId: initialRow.doc._id,
+          repository,
+          combined,
+          installationId: installation.id
+        }
+      }
+    }
+
     return {
       data: {
         name: 'create-initial-pr',

--- a/test/jobs/create-initial-pr-comment.js
+++ b/test/jobs/create-initial-pr-comment.js
@@ -1,0 +1,181 @@
+const { test } = require('tap')
+const nock = require('nock')
+const worker = require('../../jobs/create-initial-pr-comment')
+const upsert = require('../../lib/upsert')
+
+const dbs = require('../../lib/dbs')
+
+const waitFor = (milliseconds) => {
+  return new Promise((resolve) => {
+    setTimeout(resolve, milliseconds)
+  })
+}
+
+test('create-initial-pr-comment', async t => {
+  const { installations, repositories } = await dbs()
+  const runWorker = async () => {
+    const branchDoc = await repositories.get('42:branch:deadbeef')
+    const repository = await repositories.get('42')
+    return worker({
+      accountId: '123',
+      branchDoc,
+      prDocId: '42:pr:1234',
+      repository,
+      combined: {state: 'success'},
+      installationId: '123'
+    })
+  }
+  let githubNock
+
+  t.beforeEach(async () => {
+    githubNock = nock('https://api.github.com')
+      .post('/installations/123/access_tokens')
+      .reply(200, {
+        token: 'secret'
+      })
+      .get('/rate_limit')
+      .reply(200, {})
+      .get('/repos/finnp/test')
+      .reply(200, {
+        name: 'test',
+        html_url: 'https://github.com/finnp/test',
+        newBranch: 'greenkeeper/initial'
+      })
+
+    await installations.put({
+      _id: '123',
+      installation: 37
+    })
+
+    await repositories.put({
+      _id: '42',
+      id: '42',
+      accountId: '123',
+      enabled: false,
+      fullName: 'finnp/test',
+      owner: {
+        id: 123
+      }
+    })
+
+    await repositories.put({
+      _id: '42:branch:deadbeef',
+      type: 'branch',
+      initial: true,
+      sha: 'deadbeef',
+      base: 'master',
+      head: 'greenkeeper/initial',
+      processed: false,
+      depsUpdated: true,
+      travisModified: true,
+      badgeAdded: true,
+      badgeUrl: 'url'
+    })
+
+    await repositories.put({
+      _id: '42:pr:1234',
+      repositoryId: '42',
+      accountId: '123',
+      type: 'pr',
+      initial: true,
+      number: 1234,
+      head: 'greenkeeper/initial',
+      state: 'open'
+    })
+  })
+
+  t.afterEach(async () => {
+    nock.cleanAll()
+    await installations.remove(await installations.get('123'))
+    await repositories.remove(await repositories.get('42'))
+    await repositories.remove(await repositories.get('42:branch:deadbeef'))
+    await repositories.remove(await repositories.get('42:pr:1234'))
+  })
+
+  t.test('create comment for initial pr created by user', async t => {
+    t.plan(2)
+
+    githubNock
+      .get('/repos/finnp/test/issues/1234')
+      .reply(200, {
+        state: 'open',
+        locked: false
+      })
+      .post('/repos/finnp/test/issues/1234/comments')
+      .reply(201, () => {
+        t.pass('comment added')
+        return {}
+      })
+
+    await runWorker()
+
+    const prDoc = await repositories.get('42:pr:1234')
+    t.ok(prDoc.initialPrCommentSent, 'initialPrCommentSent set to true')
+    await waitFor(50)
+  })
+
+  t.test('does nothing if the repo has already received the comment', async t => {
+    t.plan(1)
+
+    await upsert(repositories, '42:pr:1234', {initialPrCommentSent: true})
+
+    githubNock
+      .get('/repos/finnp/test/issues/1234')
+      .reply(200, () => {
+        t.fail('Should not query issue status')
+        return {}
+      })
+      .post('/repos/finnp/test/issues/1234/comments')
+      .reply(201, () => {
+        t.fail('Should not post comment')
+        return {}
+      })
+
+    const newJob = await runWorker()
+
+    t.notOk(newJob, 'no new job')
+    await waitFor(50)
+  })
+
+  t.test('does nothing if the issue was closed in the meanwhile', async t => {
+    t.plan(1)
+
+    githubNock
+      .get('/repos/finnp/test/issues/1234')
+      .reply(200, {
+        state: 'closed',
+        locked: false
+      })
+      .post('/repos/finnp/test/issues/1234/comments')
+      .reply(201, () => {
+        t.fail('Should not post comment')
+        return {}
+      })
+
+    const newJob = await runWorker()
+
+    t.notOk(newJob, 'no new job')
+    await waitFor(50)
+  })
+
+  t.test('does nothing if the issue was locked in the meanwhile', async t => {
+    t.plan(1)
+
+    githubNock
+      .get('/repos/finnp/test/issues/1234')
+      .reply(200, {
+        state: 'open',
+        locked: true
+      })
+      .post('/repos/finnp/test/issues/1234/comments')
+      .reply(201, () => {
+        t.fail('Should not post comment')
+        return {}
+      })
+
+    const newJob = await runWorker()
+
+    t.notOk(newJob, 'no new job')
+    await waitFor(50)
+  })
+})

--- a/test/jobs/github-event/pull_request/opened.js
+++ b/test/jobs/github-event/pull_request/opened.js
@@ -1,0 +1,107 @@
+const { test, tearDown } = require('tap')
+const dbs = require('../../../../lib/dbs')
+const worker = require('../../../../jobs/github-event/pull_request/opened')
+
+const pullRequestPayLoad = (id, branchName, user) => {
+  return {
+    installation: {
+      id: 37
+    },
+    pull_request: {
+      id,
+      merged: false,
+      state: 'open',
+      head: {
+        ref: branchName
+      },
+      user
+    },
+    repository: {
+      full_name: 'finnp/test',
+      id: 42,
+      owner: {
+        id: 10
+      }
+    }
+  }
+}
+
+test('github-event pull_request opened', async t => {
+  const { repositories } = await dbs()
+  await repositories.put({
+    _id: '42',
+    enabled: false,
+    repositoryId: '42'
+  })
+
+  t.test('initial pr opened by user', async t => {
+    const newJob = await worker(
+      pullRequestPayLoad(666, 'greenkeeper/initial', {
+        type: 'User',
+        login: 'finnp'
+      })
+    )
+
+    t.notOk(newJob, 'no new job')
+    const pr = await repositories.get('42:pr:666')
+    t.is(pr.state, 'open', 'pr status is opened')
+    t.is(pr.merged, false, 'pr is not merged')
+    t.is(pr.initial, true, 'is initial pr')
+    t.ok(pr.createdAt, 'createdAt is set')
+    t.is(pr.createdByUser, true, 'pr is created by the user')
+    t.end()
+  })
+
+  t.test('initial pr opened by greenkeeper', async t => {
+    const newJob = await worker(
+      pullRequestPayLoad(667, 'greenkeeper/initial', {
+        type: 'Bot',
+        login: 'greenkeeper[bot]'
+      })
+    )
+
+    t.notOk(newJob, 'no new job')
+    try {
+      await repositories.get('42:pr:667')
+      t.fail('unexpected prdoc in database')
+    } catch (e) {
+      t.equals(e.status, 404, 'prdoc was not created')
+    }
+    t.end()
+  })
+
+  t.test('pr opened but is not our initial branch', async t => {
+    const newJob = await worker(
+      pullRequestPayLoad(668, 'some-random-branch', {
+        type: 'User',
+        login: 'finnp'
+      })
+    )
+
+    t.notOk(newJob, 'no new job')
+    try {
+      await repositories.get('42:pr:668')
+      t.fail('unexpected prdoc in database')
+    } catch (e) {
+      t.equals(e.status, 404, 'prdoc was not created')
+    }
+    t.end()
+  })
+})
+
+tearDown(async () => {
+  const { repositories } = await dbs()
+  await repositories.remove(await repositories.get('42:pr:666'))
+  await repositories.remove(await repositories.get('42'))
+  const docIds = [667, 668]
+
+  docIds.forEach(async (docId) => {
+    try {
+      await repositories.remove(await repositories.get(`42:pr:${docId}`))
+    } catch (e) {
+      if (e.status !== 404) {
+        throw e
+      }
+    }
+  })
+})


### PR DESCRIPTION
With this feature Greenkeeper can also be enabled when the user creates the initial pr (from the greenkeeper/inital branch)

Todo:
- [x] comment on pr with initial instructions
- [x] check if payment 'warnings' will be shown