### PR TITLE
chores: make start-couchdb wait for CouchDB being available

### DIFF
--- a/start-couchdb
+++ b/start-couchdb
@@ -5,4 +5,19 @@ set -e
 
 docker rm -fv gk-couchdb || true
 docker run -d -p 5984:5984 --name gk-couchdb klaemo/couchdb:2.0.0
-sleep 1.5
+
+TIMEOUT=60
+TRIES=0
+printf 'Waiting for CouchDB to be available to us'
+
+until $(curl --output /dev/null --silent --head --fail http://localhost:5984); do
+  printf '.'
+  TRIES=$TRIES+1
+
+  if [[ $TRIES -eq $TIMEOUT ]]; then
+    echo 'Timed out waiting for CouchDB to be available'
+    exit 1
+  fi
+
+  sleep 1
+done


### PR DESCRIPTION
Previously, when running `npm test`, the couchdb docker container sometimes took
longer than expected to be available to use, which lead to test
failures.

With this in place, we wait for the container to be available and then
start the test. This times out after 60 seconds of waiting.