### PR TITLE
fix(registry-change): ignore peerDependencies

### DIFF
--- a/jobs/registry-change.js
+++ b/jobs/registry-change.js
@@ -62,36 +62,38 @@ module.exports = async function (
     '_id'
   )
 
-  return packages.map(pkg => {
-    const account = accounts[pkg.value.accountId]
-    const plan = account.plan
+  return packages
+    .filter(pkg => pkg.value.type !== 'peerDependencies')
+    .map(pkg => {
+      const account = accounts[pkg.value.accountId]
+      const plan = account.plan
 
-    const satisfyingVersions = Object.keys(versions)
-      .filter(version => semver.satisfies(version, pkg.value.oldVersion))
-      .sort(semver.rcompare)
+      const satisfyingVersions = Object.keys(versions)
+        .filter(version => semver.satisfies(version, pkg.value.oldVersion))
+        .sort(semver.rcompare)
 
-    const oldVersionResolved = satisfyingVersions[0] === distTags[distTag]
-      ? satisfyingVersions[1]
-      : satisfyingVersions[0]
+      const oldVersionResolved = satisfyingVersions[0] === distTags[distTag]
+        ? satisfyingVersions[1]
+        : satisfyingVersions[0]
 
-    if (isFromHook && String(account.installation) !== installation) return {}
+      if (isFromHook && String(account.installation) !== installation) return {}
 
-    return {
-      data: Object.assign(
-        {
-          name: 'create-version-branch',
-          dependency,
-          distTags,
-          distTag,
-          versions,
-          oldVersionResolved,
-          repositoryId: pkg.id,
-          installation: account.installation,
-          plan
-        },
-        pkg.value
-      ),
-      plan
-    }
-  })
+      return {
+        data: Object.assign(
+          {
+            name: 'create-version-branch',
+            dependency,
+            distTags,
+            distTag,
+            versions,
+            oldVersionResolved,
+            repositoryId: pkg.id,
+            installation: account.installation,
+            plan
+          },
+          pkg.value
+        ),
+        plan
+      }
+    })
 }

--- a/test/jobs/registry-change.js
+++ b/test/jobs/registry-change.js
@@ -44,6 +44,12 @@ test('registry change create jobs', async t => {
       distTags: {
         latest: '1.0.0'
       }
+    }),
+    npm.put({
+      _id: 'eslint',
+      distTags: {
+        latest: '1.0.0'
+      }
     })
   ])
 
@@ -106,6 +112,40 @@ test('registry change create jobs', async t => {
     tt.end()
   })
 
+  t.test('registry change skip peerDependencies', async tt => {
+    tt.plan(1)
+    await repositories.put({
+      _id: '776',
+      enabled: true,
+      type: 'repository',
+      fullName: 'owner/repo2',
+      accountId: '999',
+      packages: {
+        'package.json': {
+          peerDependencies: {
+            eslint: '1.0.0'
+          }
+        }
+      }
+    })
+
+    const newJobs = await worker({
+      name: 'registry-change',
+      dependency: 'eslint',
+      distTags: {
+        latest: '9.0.0'
+      },
+      versions: {
+        '9.0.0': {
+          gitHead: 'b75aeb1'
+        }
+      },
+      registry: 'https://skimdb.npmjs.com/registry'
+    })
+
+    tt.is(newJobs.length, 0, 'no new jobs')
+    tt.end()
+  })
   t.end()
 })
 
@@ -115,5 +155,7 @@ tearDown(async () => {
   await installations.remove(await installations.get('999'))
   await repositories.remove(await repositories.get('888'))
   await repositories.remove(await repositories.get('777'))
+  await repositories.remove(await repositories.get('776'))
   await npm.remove(await npm.get('standard'))
+  await npm.remove(await npm.get('eslint'))
 })


### PR DESCRIPTION
so a (dev)dependency update will not accidentally update a peerDependency
or a pull request with the update will not be closed by Greenkeeper because
update is in the peerDependency range.