### PR TITLE
fix(travis): pin npm to 5.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ notifications:
   email: false
 node_js: 7
 before_install:
-- npm install -g npm@5
+- npm install -g npm@5.2.0
 - npm install -g greenkeeper-lockfile@1
 install: npm install
 before_script: greenkeeper-lockfile-update


### PR DESCRIPTION
We've seen some issues with the lastest 5.3.0 and the
`node_modules/.bin` directory. Pinning to 5.2.0 solves this issue.

See https://github.com/npm/npm/issues/17882#issuecomment-317431382 for
some details.