### PR TITLE
✨  Adapt to GitHub marketplace

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ require('./lib/rollbar')
 
   async function consume (job) {
     const data = JSON.parse(job.content.toString())
-    const jobsWithoutOwners = ['registry-change', 'stripe-event', 'schedule-stale-initial-pr-reminders', 'reset']
+    const jobsWithoutOwners = ['registry-change', 'stripe-event', 'schedule-stale-initial-pr-reminders', 'reset', 'cancel-stripe-subscription']
     if (jobsWithoutOwners.includes(data.name)) {
       return queueJob(data.name, job)
     }

--- a/jobs/cancel-stripe-subscription.js
+++ b/jobs/cancel-stripe-subscription.js
@@ -1,0 +1,19 @@
+const env = require('../lib/env')
+const stripe = require('stripe')(env.STRIPE_SECRET_KEY)
+const dbs = require('../lib/dbs')
+const upsert = require('../lib/upsert')
+
+module.exports = async function ({ accountId, stripeSubscriptionId }) {
+  const { payments } = await dbs()
+  await stripe.subscriptions.del(
+    stripeSubscriptionId,
+    async (err, confirmation) => {
+      if (err) {
+        throw err
+      }
+      await upsert(payments, accountId, {
+        stripeSubscriptionId: null
+      })
+    }
+  )
+}

--- a/jobs/cancel-stripe-subscription.js
+++ b/jobs/cancel-stripe-subscription.js
@@ -7,6 +7,7 @@ module.exports = async function ({ accountId, stripeSubscriptionId }) {
   const { payments } = await dbs()
   await stripe.subscriptions.del(stripeSubscriptionId)
   await upsert(payments, accountId, {
-    stripeSubscriptionId: null
+    stripeSubscriptionId: null,
+    stripeItemId: null
   })
 }

--- a/jobs/cancel-stripe-subscription.js
+++ b/jobs/cancel-stripe-subscription.js
@@ -5,15 +5,8 @@ const upsert = require('../lib/upsert')
 
 module.exports = async function ({ accountId, stripeSubscriptionId }) {
   const { payments } = await dbs()
-  await stripe.subscriptions.del(
-    stripeSubscriptionId,
-    async (err, confirmation) => {
-      if (err) {
-        throw err
-      }
-      await upsert(payments, accountId, {
-        stripeSubscriptionId: null
-      })
-    }
-  )
+  await stripe.subscriptions.del(stripeSubscriptionId)
+  await upsert(payments, accountId, {
+    stripeSubscriptionId: null
+  })
 }

--- a/jobs/create-initial-pr.js
+++ b/jobs/create-initial-pr.js
@@ -58,10 +58,10 @@ module.exports = async function (
   }))
 
   const billingAccount = await getActiveBilling(accountId)
-  const accountHasBilling = !!billingAccount
+  const hasBillingAccount = !!billingAccount
   const accountNeedsMarketplaceUpgrade = await getAccountNeedsMarketplaceUpgrade(accountId)
 
-  if (repodoc.private && (!accountHasBilling || accountNeedsMarketplaceUpgrade)) {
+  if (repodoc.private && (!hasBillingAccount || accountNeedsMarketplaceUpgrade)) {
     const targetUrl = accountNeedsMarketplaceUpgrade ? 'https://github.com/marketplace/greenkeeper/' : 'https://account.greenkeeper.io/'
 
     await ghqueue.write(github => github.repos.createStatus({

--- a/jobs/create-version-branch.js
+++ b/jobs/create-version-branch.js
@@ -11,7 +11,7 @@ const statsd = require('../lib/statsd')
 const env = require('../lib/env')
 const githubQueue = require('../lib/github-queue')
 const upsert = require('../lib/upsert')
-const { getActiveBilling } = require('../lib/payments')
+const { getActiveBilling, getAccountNeedsMarketplaceUpgrade } = require('../lib/payments')
 
 const prContent = require('../content/update-pr')
 
@@ -44,8 +44,7 @@ module.exports = async function (
   if (satisfies && hasLockFile) return
 
   const billing = await getActiveBilling(accountId)
-
-  if (repository.private && !billing) return
+  if (repository.private && (!billing || await getAccountNeedsMarketplaceUpgrade(accountId))) return
 
   const [owner, repo] = repository.fullName.split('/')
   const config = getConfig(repository)

--- a/jobs/github-event/marketplace_purchase/cancelled.js
+++ b/jobs/github-event/marketplace_purchase/cancelled.js
@@ -1,0 +1,11 @@
+const dbs = require('../../../lib/dbs')
+const upsert = require('../../../lib/upsert')
+
+module.exports = async function ({ marketplace_purchase }) {
+  const { payments } = await dbs()
+  const accountId = String(marketplace_purchase.account.id)
+
+  await upsert(payments, accountId, {
+    plan: 'free'
+  })
+}

--- a/jobs/github-event/marketplace_purchase/changed.js
+++ b/jobs/github-event/marketplace_purchase/changed.js
@@ -1,0 +1,11 @@
+const dbs = require('../../../lib/dbs')
+const upsert = require('../../../lib/upsert')
+
+module.exports = async function ({ marketplace_purchase }) {
+  const { payments } = await dbs()
+  const accountId = String(marketplace_purchase.account.id)
+
+  await upsert(payments, accountId, {
+    plan: marketplace_purchase.plan.name.toLowerCase().replace(' ', '')
+  })
+}

--- a/jobs/github-event/marketplace_purchase/changed.js
+++ b/jobs/github-event/marketplace_purchase/changed.js
@@ -1,11 +1,12 @@
 const dbs = require('../../../lib/dbs')
 const upsert = require('../../../lib/upsert')
+const normalizePlanName = require('../../../lib/normalize-plan-name')
 
 module.exports = async function ({ marketplace_purchase }) {
   const { payments } = await dbs()
   const accountId = String(marketplace_purchase.account.id)
 
   await upsert(payments, accountId, {
-    plan: marketplace_purchase.plan.name.toLowerCase().replace(' ', '')
+    plan: normalizePlanName(marketplace_purchase.plan.name)
   })
 }

--- a/jobs/github-event/marketplace_purchase/purchased.js
+++ b/jobs/github-event/marketplace_purchase/purchased.js
@@ -1,5 +1,6 @@
 const dbs = require('../../../lib/dbs')
 const upsert = require('../../../lib/upsert')
+const normalizePlanName = require('../../../lib/normalize-plan-name')
 
 module.exports = async function ({ marketplace_purchase }) {
   const { payments } = await dbs()
@@ -8,7 +9,7 @@ module.exports = async function ({ marketplace_purchase }) {
   let paymentDoc
 
   await upsert(payments, accountId, {
-    plan: marketplace_purchase.plan.name.toLowerCase().replace(' ', '')
+    plan: normalizePlanName(marketplace_purchase.plan.name)
   })
 
   try {

--- a/jobs/github-event/marketplace_purchase/purchased.js
+++ b/jobs/github-event/marketplace_purchase/purchased.js
@@ -1,0 +1,29 @@
+const dbs = require('../../../lib/dbs')
+const upsert = require('../../../lib/upsert')
+
+module.exports = async function ({ marketplace_purchase }) {
+  const { payments } = await dbs()
+
+  const accountId = String(marketplace_purchase.account.id)
+  let paymentDoc
+
+  await upsert(payments, accountId, {
+    plan: marketplace_purchase.plan.name.toLowerCase().replace(' ', '')
+  })
+
+  try {
+    paymentDoc = await payments.get(String(accountId))
+  } catch (error) {
+    if (error.status !== 404) throw error
+  }
+
+  if (paymentDoc && paymentDoc.stripeSubscriptionId) {
+    return {
+      data: {
+        name: 'cancel-stripe-subscription',
+        accountId: paymentDoc._id,
+        stripeSubscriptionId: paymentDoc.stripeSubscriptionId
+      }
+    }
+  }
+}

--- a/jobs/github-event/pull_request/closed.js
+++ b/jobs/github-event/pull_request/closed.js
@@ -3,6 +3,7 @@ const _ = require('lodash')
 const githubQueue = require('../../../lib/github-queue')
 const dbs = require('../../../lib/dbs')
 const upsert = require('../../../lib/upsert')
+const { hasStripeBilling } = require('../../../lib/payments')
 
 module.exports = async function (data) {
   const { repositories } = await dbs()
@@ -40,7 +41,7 @@ module.exports = async function (data) {
     }))
   } catch (e) {}
 
-  if (repodoc.private) {
+  if (repodoc.private && (await hasStripeBilling(accountId))) {
     return {
       data: {
         name: 'update-payments',

--- a/jobs/github-event/pull_request/opened.js
+++ b/jobs/github-event/pull_request/opened.js
@@ -38,10 +38,10 @@ module.exports = async function (data) {
   const ghqueue = githubQueue(installation.id)
 
   const billingAccount = await getActiveBilling(accountId)
-  const accountHasBilling = !!billingAccount
+  const hasBillingAccount = !!billingAccount
   const accountNeedsMarketplaceUpgrade = await getAccountNeedsMarketplaceUpgrade(accountId)
 
-  if (repoDoc.private && ((!accountHasBilling || accountNeedsMarketplaceUpgrade))) {
+  if (repoDoc.private && ((!hasBillingAccount || accountNeedsMarketplaceUpgrade))) {
     const targetUrl = accountNeedsMarketplaceUpgrade ? 'https://github.com/marketplace/greenkeeper/' : 'https://account.greenkeeper.io/'
 
     await ghqueue.write(github => github.repos.createStatus({

--- a/jobs/github-event/push.js
+++ b/jobs/github-event/push.js
@@ -5,6 +5,7 @@ const { updateRepoDoc } = require('../../lib/repository-docs')
 const updatedAt = require('../../lib/updated-at')
 const diff = require('../../lib/diff-package-json')
 const deleteBranches = require('../../lib/delete-branches')
+const { hasStripeBilling } = require('../../lib/payments')
 
 module.exports = async function (data) {
   const { repositories } = await dbs()
@@ -106,7 +107,7 @@ function hasRelevantChanges (commits, files) {
 async function disableRepo ({ repositories, repodoc, repository }) {
   repodoc.enabled = false
   await updateDoc(repositories, repository, repodoc)
-  if (repodoc.private) {
+  if (repodoc.private && (await hasStripeBilling(repodoc.accountId))) {
     return {
       data: {
         name: 'update-payments',

--- a/jobs/update-payments.js
+++ b/jobs/update-payments.js
@@ -5,6 +5,8 @@ const stripe = require('stripe')(env.STRIPE_SECRET_KEY)
 module.exports = async ({ accountId, repositoryId }) => {
   const billingAccount = await getActiveBilling(accountId)
     // ignore non-stripe users
+    // checking for stripeSubscriptionId instead of stripeItemId because in
+    // jobs/stripe-event.js L33-L40 only then stripeSubscriptionId is set to null
   if (!billingAccount || !billingAccount.stripeSubscriptionId) return
 
   const currentlyPrivateAndEnabledRepos = await getAmountOfCurrentlyPrivateAndEnabledRepos(accountId)

--- a/jobs/update-payments.js
+++ b/jobs/update-payments.js
@@ -1,5 +1,5 @@
 const env = require('../lib/env')
-const { getActiveBilling, getCurrentlyPrivateAndEnabledRepos } = require('../lib/payments')
+const { getActiveBilling, getAmountOfCurrentlyPrivateAndEnabledRepos } = require('../lib/payments')
 const stripe = require('stripe')(env.STRIPE_SECRET_KEY)
 
 module.exports = async ({ accountId, repositoryId }) => {
@@ -7,7 +7,7 @@ module.exports = async ({ accountId, repositoryId }) => {
     // ignore non-stripe users
   if (!billingAccount || !billingAccount.stripeSubscriptionId) return
 
-  const currentlyPrivateAndEnabledRepos = await getCurrentlyPrivateAndEnabledRepos(accountId)
+  const currentlyPrivateAndEnabledRepos = await getAmountOfCurrentlyPrivateAndEnabledRepos(accountId)
 
   // charge for new repo from Stripe
   const baseRepos = billingAccount.plan === 'org' ? 10 : 0

--- a/jobs/update-payments.js
+++ b/jobs/update-payments.js
@@ -7,7 +7,7 @@ module.exports = async ({ accountId, repositoryId }) => {
     // ignore non-stripe users
   if (!billingAccount || !billingAccount.stripeSubscriptionId) return
 
-  const currentlyPrivateAndEnabledRepos = getCurrentlyPrivateAndEnabledRepos(accountId)
+  const currentlyPrivateAndEnabledRepos = await getCurrentlyPrivateAndEnabledRepos(accountId)
 
   // charge for new repo from Stripe
   const baseRepos = billingAccount.plan === 'org' ? 10 : 0

--- a/lib/normalize-plan-name.js
+++ b/lib/normalize-plan-name.js
@@ -1,0 +1,3 @@
+module.exports = function normalizePlanName (planName) {
+  return planName.toLowerCase().replace(' ', '')
+}

--- a/lib/payments.js
+++ b/lib/payments.js
@@ -49,8 +49,8 @@ async function getAccountNeedsMarketplaceUpgrade (accountId) {
   if (paymentDoc.plan === 'opensource') return true
   if (paymentDoc.plan === 'team') {
     console.log('***TEAM***')
-    console.log('***Repos***', await getCurrentlyPrivateAndEnabledRepos(accountId))
-    if (await getCurrentlyPrivateAndEnabledRepos(accountId) >= 15) {
+    console.log('***Repos***', await module.exports.getCurrentlyPrivateAndEnabledRepos(accountId))
+    if (await module.exports.getCurrentlyPrivateAndEnabledRepos(accountId) >= 15) {
       console.log('***TEAM OVER LIMIT***')
       return true // team plan & repo limit reached
     }

--- a/lib/payments.js
+++ b/lib/payments.js
@@ -1,6 +1,8 @@
 const _ = require('lodash')
 const dbs = require('../lib/dbs')
 
+const validPaidPlanNames = ['org', 'personal', 'team', 'business']
+
 async function hasStripeBilling (accountId) {
   const activeBilling = await getActiveBilling(accountId)
   return !!activeBilling && !!activeBilling.stripeSubscriptionId
@@ -12,7 +14,7 @@ async function getActiveBilling (accountId) {
   try {
     const doc = await payments.get(String(accountId))
     const { plan } = doc
-    if (plan === 'org' || plan === 'personal' || plan === 'team' || plan === 'business') return doc
+    if (validPaidPlanNames.includes(plan)) return doc
   } catch (e) {
     if (e.status !== 404) throw e
   }

--- a/lib/payments.js
+++ b/lib/payments.js
@@ -43,18 +43,18 @@ async function getCurrentlyPrivateAndEnabledRepos (accountId) {
 
 async function getAccountNeedsMarketplaceUpgrade (accountId) {
   const { payments } = await dbs()
-  const paymentDoc = await payments.get(String(accountId))
-
-  if (!paymentDoc.plan) return false
-  if (paymentDoc.plan === 'opensource') return true
-  if (paymentDoc.plan === 'team') {
-    console.log('***TEAM***')
-    console.log('***Repos***', await module.exports.getCurrentlyPrivateAndEnabledRepos(accountId))
-    if (await module.exports.getCurrentlyPrivateAndEnabledRepos(accountId) >= 15) {
-      console.log('***TEAM OVER LIMIT***')
-      return true // team plan & repo limit reached
+  try {
+    const paymentDoc = await payments.get(String(accountId))
+    if (!paymentDoc.plan) return false
+    if (paymentDoc.plan === 'opensource') return true
+    if (paymentDoc.plan === 'team') {
+      if (await module.exports.getCurrentlyPrivateAndEnabledRepos(accountId) >= 15) {
+        return true // team plan & repo limit reached
+      }
+      return false // team plan & repo limit *not* reached
     }
-    return false // team plan & repo limit *not* reached
+  } catch (error) {
+    if (error.status !== 404) throw error
   }
   return false // all other plans plan
 }

--- a/lib/payments.js
+++ b/lib/payments.js
@@ -1,7 +1,9 @@
+const _ = require('lodash')
 const dbs = require('../lib/dbs')
 
-async function hasBilling (accountId) {
-  return !!await getActiveBilling(accountId)
+async function hasStripeBilling (accountId) {
+  const activeBilling = await getActiveBilling(accountId)
+  return !!activeBilling && !!activeBilling.stripeSubscriptionId
 }
 
 async function getActiveBilling (accountId) {
@@ -10,7 +12,7 @@ async function getActiveBilling (accountId) {
   try {
     const doc = await payments.get(String(accountId))
     const { plan } = doc
-    if (plan === 'org' || plan === 'personal') return doc
+    if (plan === 'org' || plan === 'personal' || plan === 'team' || plan === 'business') return doc
   } catch (e) {
     if (e.status !== 404) throw e
   }
@@ -18,7 +20,7 @@ async function getActiveBilling (accountId) {
 }
 
 async function maybeUpdatePaymentsJob (accountId, isPrivate) {
-  if (isPrivate && (await hasBilling(accountId))) {
+  if (isPrivate && (await hasStripeBilling(accountId))) {
     return {
       data: {
         name: 'update-payments',
@@ -28,8 +30,39 @@ async function maybeUpdatePaymentsJob (accountId, isPrivate) {
   }
 }
 
+async function getCurrentlyPrivateAndEnabledRepos (accountId) {
+  const { repositories } = await dbs()
+
+  const billing = await repositories.query('billing', {
+    key: accountId,
+    group_level: 1,
+    reduce: true
+  })
+  return _.get(billing, 'rows[0].value', 0)
+}
+
+async function getAccountNeedsMarketplaceUpgrade (accountId) {
+  const { payments } = await dbs()
+  const paymentDoc = await payments.get(String(accountId))
+
+  if (!paymentDoc.plan) return false
+  if (paymentDoc.plan === 'opensource') return true
+  if (paymentDoc.plan === 'team') {
+    console.log('***TEAM***')
+    console.log('***Repos***', await getCurrentlyPrivateAndEnabledRepos(accountId))
+    if (await getCurrentlyPrivateAndEnabledRepos(accountId) >= 15) {
+      console.log('***TEAM OVER LIMIT***')
+      return true // team plan & repo limit reached
+    }
+    return false // team plan & repo limit *not* reached
+  }
+  return false // all other plans plan
+}
+
 module.exports = {
-  hasBilling,
+  hasStripeBilling,
   getActiveBilling,
-  maybeUpdatePaymentsJob
+  maybeUpdatePaymentsJob,
+  getCurrentlyPrivateAndEnabledRepos,
+  getAccountNeedsMarketplaceUpgrade
 }

--- a/lib/payments.js
+++ b/lib/payments.js
@@ -30,7 +30,7 @@ async function maybeUpdatePaymentsJob (accountId, isPrivate) {
   }
 }
 
-async function getCurrentlyPrivateAndEnabledRepos (accountId) {
+async function getAmountOfCurrentlyPrivateAndEnabledRepos (accountId) {
   const { repositories } = await dbs()
 
   const billing = await repositories.query('billing', {
@@ -48,7 +48,7 @@ async function getAccountNeedsMarketplaceUpgrade (accountId) {
     if (!paymentDoc.plan) return false
     if (paymentDoc.plan === 'opensource') return true
     if (paymentDoc.plan === 'team') {
-      if (await module.exports.getCurrentlyPrivateAndEnabledRepos(accountId) >= 15) {
+      if (await module.exports.getAmountOfCurrentlyPrivateAndEnabledRepos(accountId) >= 15) {
         return true // team plan & repo limit reached
       }
       return false // team plan & repo limit *not* reached
@@ -63,6 +63,6 @@ module.exports = {
   hasStripeBilling,
   getActiveBilling,
   maybeUpdatePaymentsJob,
-  getCurrentlyPrivateAndEnabledRepos,
+  getAmountOfCurrentlyPrivateAndEnabledRepos,
   getAccountNeedsMarketplaceUpgrade
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2477,13 +2477,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -2491,6 +2484,13 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -2930,11 +2930,6 @@
       "integrity": "sha1-y8NcYu7uc/Gat7EKgBURQBr8D5A=",
       "dev": true
     },
-    "is_js": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/is_js/-/is_js-0.9.0.tgz",
-      "integrity": "sha1-CrlFQFArp6+iTIVqqYVWFmnpxS0="
-    },
     "is-array-buffer-x": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-array-buffer-x/-/is-array-buffer-x-1.2.1.tgz",
@@ -3149,6 +3144,11 @@
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
       "dev": true
+    },
+    "is_js": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/is_js/-/is_js-0.9.0.tgz",
+      "integrity": "sha1-CrlFQFArp6+iTIVqqYVWFmnpxS0="
     },
     "isarray": {
       "version": "0.0.1",
@@ -6659,6 +6659,12 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
+    "simple-mock": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/simple-mock/-/simple-mock-0.8.0.tgz",
+      "integrity": "sha1-ScmiI/pu6o4sT9aUj+gwDNillPM=",
+      "dev": true
+    },
     "slice-ansi": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
@@ -6961,11 +6967,6 @@
       "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz",
       "integrity": "sha1-pB6tGm1ggc63n2WwYZAbbY89HQ8="
     },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -6975,6 +6976,11 @@
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
       }
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
     "stringstream": {
       "version": "0.0.5",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "nyc": "^11.0.3",
     "prettier-standard-formatter": "^0.222222222222222.333333333333333",
     "proxyquire": "^1.7.10",
+    "simple-mock": "^0.8.0",
     "standard": "^10.0.2",
     "tap": "^10.0.1"
   },

--- a/test/jobs/cancel-stripe-subscription.js
+++ b/test/jobs/cancel-stripe-subscription.js
@@ -9,7 +9,7 @@ nock.enableNetConnect('localhost')
 
 test('Cancel Stripe Subscription', async t => {
   const { payments } = await dbs()
-  t.plan(2)
+  t.plan(3)
 
   nock('https://api.stripe.com/v1')
     .delete('/subscriptions/345')
@@ -34,6 +34,7 @@ test('Cancel Stripe Subscription', async t => {
   })
 
   const payment = await payments.get('123')
+  t.is(payment.stripeItemId, null)
   t.is(payment.stripeSubscriptionId, null)
   t.end()
 })

--- a/test/jobs/cancel-stripe-subscription.js
+++ b/test/jobs/cancel-stripe-subscription.js
@@ -1,0 +1,44 @@
+const { test, tearDown } = require('tap')
+const nock = require('nock')
+const worker = require('../../jobs/cancel-stripe-subscription')
+
+const dbs = require('../../lib/dbs')
+
+nock.disableNetConnect()
+nock.enableNetConnect('localhost')
+
+test('Cancel Stripe Subscription', async t => {
+  const { payments } = await dbs()
+  t.plan(2)
+
+  nock('https://api.stripe.com/v1')
+    .delete('/subscriptions/345')
+    .reply(200, () => {
+      t.pass('Stripe called')
+      return {
+        stripeSubscriptionId: '345'
+      }
+    })
+
+  await payments.put({
+    _id: '123',
+    plan: 'team',
+    stripeCustomerId: 'cus_abc',
+    stripeItemId: 'si_xyz',
+    stripeSubscriptionId: '345'
+  })
+
+  await worker({
+    accountId: '123',
+    stripeSubscriptionId: '345'
+  })
+
+  const payment = await payments.get('123')
+  t.is(payment.stripeSubscriptionId, null)
+  t.end()
+})
+
+tearDown(async () => {
+  const { payments } = await dbs()
+  await payments.remove(await payments.get('123'))
+})

--- a/test/jobs/create-initial-pr.js
+++ b/test/jobs/create-initial-pr.js
@@ -1,35 +1,60 @@
 const { test, tearDown } = require('tap')
 const nock = require('nock')
+const proxyquire = require('proxyquire')
 
 const dbs = require('../../lib/dbs')
+const createInitial = require('../../jobs/create-initial-pr')
 
-test('create-initial-branch', async t => {
-  const { installations, repositories } = await dbs()
+test('create-initial-pr', async t => {
+  const { repositories, payments } = await dbs()
 
-  await installations.put({
-    _id: '123',
-    installation: 37,
+  await payments.put({
+    _id: '123free',
     plan: 'free'
   })
 
-  t.test('create pr', async t => {
+  await payments.put({
+    _id: '123opensource',
+    plan: 'opensource'
+  })
+
+  await payments.put({
+    _id: '123stripe',
+    plan: 'personal',
+    stripeSubscriptionId: 'si123'
+  })
+
+  await payments.put({
+    _id: '123team',
+    plan: 'team'
+  })
+
+  await payments.put({
+    _id: '123business',
+    plan: 'business'
+  })
+
+  await repositories.put({
+    _id: 'repoId:branch:1234abcd',
+    type: 'branch',
+    initial: true,
+    sha: '1234abcd',
+    base: 'master',
+    head: 'greenkeeper/initial',
+    processed: false,
+    depsUpdated: true,
+    badgeUrl: 'https://badges.greenkeeper.io/finnp/test.svg',
+    createdAt: '2017-01-13T17:33:56.698Z',
+    updatedAt: '2017-01-13T17:33:56.698Z'
+  })
+
+  const branchDoc = await repositories.get('repoId:branch:1234abcd')
+
+  t.test('create pr for account with `free` plan', async t => {
     await repositories.put({
       _id: '42',
-      accountId: '123',
+      accountId: '123free',
       fullName: 'finnp/test'
-    })
-    await repositories.put({
-      _id: '42:branch:1234abcd',
-      type: 'branch',
-      initial: true,
-      sha: '1234abcd',
-      base: 'master',
-      head: 'greenkeeper/initial',
-      processed: false,
-      depsUpdated: true,
-      badgeUrl: 'https://badges.greenkeeper.io/finnp/test.svg',
-      createdAt: '2017-01-13T17:33:56.698Z',
-      updatedAt: '2017-01-13T17:33:56.698Z'
     })
 
     t.plan(3)
@@ -70,25 +95,404 @@ test('create-initial-branch', async t => {
         return {}
       })
 
-    const createInitial = require('../../jobs/create-initial-pr')
-
     await createInitial({
       repository: { id: 42 },
-      branchDoc: await repositories.get('42:branch:1234abcd'),
+      branchDoc: branchDoc,
       combined: {
         state: 'success',
         combined: []
       },
       installationId: 11,
-      accountId: 7
+      accountId: '123free'
+    })
+  })
+
+  t.test('create pr for private repo for account with `free` plan', async t => {
+    await repositories.put({
+      _id: '42b',
+      accountId: '123free',
+      fullName: 'finnp/private',
+      private: true
+    })
+
+    t.plan(4)
+
+    nock('https://api.github.com')
+      .post('/installations/11/access_tokens')
+      .reply(200, {
+        token: 'secret'
+      })
+      .get('/rate_limit')
+      .reply(200, {})
+      .get('/repos/finnp/private')
+      .reply(200, {
+        default_branch: 'custom'
+      })
+      .post('/repos/finnp/private/statuses/1234abcd')
+      .reply(201, () => {
+        t.pass('verify status added')
+        return {}
+      })
+      .post('/repos/finnp/private/statuses/1234abcd')
+      .reply(201, () => {
+        t.pass('payment required status added')
+        return {}
+      })
+      .post(
+        '/repos/finnp/private/pulls',
+        ({ head }) => head === 'greenkeeper/initial'
+      )
+      .reply(201, () => {
+        t.pass('pull request created')
+        return {
+          id: 333,
+          number: 3
+        }
+      })
+      .post(
+        '/repos/finnp/private/issues/3/labels',
+        body => body[0] === 'greenkeeper'
+      )
+      .reply(201, () => {
+        t.pass('label created')
+        return {}
+      })
+
+    await createInitial({
+      repository: { id: '42b' },
+      branchDoc: branchDoc,
+      combined: {
+        state: 'success',
+        combined: []
+      },
+      installationId: 11,
+      accountId: '123free'
+    })
+  })
+
+  t.test('create pr for private repo for account with `opensource` plan', async t => {
+    await repositories.put({
+      _id: '46',
+      accountId: '123opensource',
+      fullName: 'finnp/private',
+      private: true
+    })
+
+    t.plan(4)
+
+    nock('https://api.github.com')
+      .post('/installations/11/access_tokens')
+      .reply(200, {
+        token: 'secret'
+      })
+      .get('/rate_limit')
+      .reply(200, {})
+      .get('/repos/finnp/private')
+      .reply(200, {
+        default_branch: 'custom'
+      })
+      .post('/repos/finnp/private/statuses/1234abcd')
+      .reply(201, () => {
+        t.pass('verify status added')
+        return {}
+      })
+      .post('/repos/finnp/private/statuses/1234abcd')
+      .reply(201, () => {
+        t.pass('payment required status added')
+        return {}
+      })
+      .post(
+        '/repos/finnp/private/pulls',
+        ({ head }) => head === 'greenkeeper/initial'
+      )
+      .reply(201, () => {
+        t.pass('pull request created')
+        return {
+          id: 333,
+          number: 3
+        }
+      })
+      .post(
+        '/repos/finnp/private/issues/3/labels',
+        body => body[0] === 'greenkeeper'
+      )
+      .reply(201, () => {
+        t.pass('label created')
+        return {}
+      })
+
+    await createInitial({
+      repository: { id: 46 },
+      branchDoc: branchDoc,
+      combined: {
+        state: 'success',
+        combined: []
+      },
+      installationId: 11,
+      accountId: '123opensource'
+    })
+  })
+
+  t.test('create pr for private repo and account with stripe `personal` plan', async t => {
+    await repositories.put({
+      _id: '43',
+      accountId: '123stripe',
+      fullName: 'finnp/private',
+      private: true
+    })
+
+    t.plan(3)
+
+    nock('https://api.github.com')
+      .post('/installations/11/access_tokens')
+      .reply(200, {
+        token: 'secret'
+      })
+      .get('/rate_limit')
+      .reply(200, {})
+      .get('/repos/finnp/private')
+      .reply(200, {
+        default_branch: 'custom'
+      })
+      .post('/repos/finnp/private/statuses/1234abcd')
+      .reply(201, () => {
+        t.pass('verify status added')
+        return {}
+      })
+      .post(
+      '/repos/finnp/private/pulls',
+      ({ head }) => head === 'greenkeeper/initial'
+      )
+      .reply(201, () => {
+        t.pass('pull request created')
+        return {
+          id: 333,
+          number: 3
+        }
+      })
+      .post(
+      '/repos/finnp/private/issues/3/labels',
+      body => body[0] === 'greenkeeper'
+      )
+      .reply(201, () => {
+        t.pass('label created')
+        return {}
+      })
+
+    await createInitial({
+      repository: { id: 43 },
+      branchDoc: branchDoc,
+      combined: {
+        state: 'success',
+        combined: []
+      },
+      installationId: 11,
+      accountId: '123stripe'
+    })
+  })
+
+  t.test('create pr for private repo and account with Github `team` plan', async t => {
+    await repositories.put({
+      _id: '44',
+      accountId: '123team',
+      fullName: 'finnp/private',
+      private: true
+    })
+
+    t.plan(3)
+
+    nock('https://api.github.com')
+      .post('/installations/11/access_tokens')
+      .reply(200, {
+        token: 'secret'
+      })
+      .get('/rate_limit')
+      .reply(200, {})
+      .get('/repos/finnp/private')
+      .reply(200, {
+        default_branch: 'custom'
+      })
+      .post('/repos/finnp/private/statuses/1234abcd')
+      .reply(201, () => {
+        t.pass('verify status added')
+        return {}
+      })
+      .post(
+      '/repos/finnp/private/pulls',
+      ({ head }) => head === 'greenkeeper/initial'
+      )
+      .reply(201, () => {
+        t.pass('pull request created')
+        return {
+          id: 333,
+          number: 3
+        }
+      })
+      .post(
+      '/repos/finnp/private/issues/3/labels',
+      body => body[0] === 'greenkeeper'
+      )
+      .reply(201, () => {
+        t.pass('label created')
+        return {}
+      })
+
+    await createInitial({
+      repository: { id: 44 },
+      branchDoc: branchDoc,
+      combined: {
+        state: 'success',
+        combined: []
+      },
+      installationId: 11,
+      accountId: '123team'
+    })
+  })
+
+  t.test('create pr for private repo and account with Github `team` plan with payment required', async t => {
+    await repositories.put({
+      _id: '44b',
+      accountId: '123team',
+      fullName: 'finnp/private',
+      private: true
+    })
+
+    t.plan(4)
+
+    nock('https://api.github.com')
+      .post('/installations/11/access_tokens')
+      .reply(200, {
+        token: 'secret'
+      })
+      .get('/rate_limit')
+      .reply(200, {})
+      .get('/repos/finnp/private')
+      .reply(200, {
+        default_branch: 'custom'
+      })
+      .post('/repos/finnp/private/statuses/1234abcd')
+      .reply(201, () => {
+        t.pass('verify status added')
+        return {}
+      })
+      .post('/repos/finnp/private/statuses/1234abcd')
+      .reply(201, () => {
+        t.pass('payment required status added')
+        return {}
+      })
+      .post(
+      '/repos/finnp/private/pulls',
+      ({ head }) => head === 'greenkeeper/initial'
+      )
+      .reply(201, () => {
+        t.pass('pull request created')
+        return {
+          id: 333,
+          number: 3
+        }
+      })
+      .post(
+      '/repos/finnp/private/issues/3/labels',
+      body => body[0] === 'greenkeeper'
+      )
+      .reply(201, () => {
+        t.pass('label created')
+        return {}
+      })
+
+    const worker = proxyquire('../../jobs/create-initial-pr', {
+      '../lib/payments': {
+        'getCurrentlyPrivateAndEnabledRepos': async (accountId) => { // Help!  not working!
+          return 15
+        }
+      }
+    })
+
+    await worker({
+      repository: { id: '44b' },
+      branchDoc: branchDoc,
+      combined: {
+        state: 'success',
+        combined: []
+      },
+      installationId: 11,
+      accountId: '123team'
+    })
+  })
+
+  t.test('create pr for private repo and account with Github `business` plan', async t => {
+    await repositories.put({
+      _id: '45',
+      accountId: '123business',
+      fullName: 'finnp/private',
+      private: true
+    })
+
+    t.plan(3)
+
+    nock('https://api.github.com')
+      .post('/installations/11/access_tokens')
+      .reply(200, {
+        token: 'secret'
+      })
+      .get('/rate_limit')
+      .reply(200, {})
+      .get('/repos/finnp/private')
+      .reply(200, {
+        default_branch: 'custom'
+      })
+      .post('/repos/finnp/private/statuses/1234abcd')
+      .reply(201, () => {
+        t.pass('verify status added')
+        return {}
+      })
+      .post(
+      '/repos/finnp/private/pulls',
+      ({ head }) => head === 'greenkeeper/initial'
+      )
+      .reply(201, () => {
+        t.pass('pull request created')
+        return {
+          id: 333,
+          number: 3
+        }
+      })
+      .post(
+      '/repos/finnp/private/issues/3/labels',
+      body => body[0] === 'greenkeeper'
+      )
+      .reply(201, () => {
+        t.pass('label created')
+        return {}
+      })
+
+    await createInitial({
+      repository: { id: 45 },
+      branchDoc: branchDoc,
+      combined: {
+        state: 'success',
+        combined: []
+      },
+      installationId: 11,
+      accountId: '123business'
     })
   })
 })
 
 tearDown(async () => {
-  const { installations, repositories } = await dbs()
+  const { repositories, payments } = await dbs()
 
-  await installations.remove(await installations.get('123'))
+  await payments.remove(await payments.get('123free'))
+  await payments.remove(await payments.get('123opensource'))
+  await payments.remove(await payments.get('123stripe'))
+  await payments.remove(await payments.get('123team'))
+  await payments.remove(await payments.get('123business'))
   await repositories.remove(await repositories.get('42'))
-  await repositories.remove(await repositories.get('42:branch:1234abcd'))
+  await repositories.remove(await repositories.get('42b'))
+  await repositories.remove(await repositories.get('43'))
+  await repositories.remove(await repositories.get('44'))
+  await repositories.remove(await repositories.get('44b'))
+  await repositories.remove(await repositories.get('45'))
+  await repositories.remove(await repositories.get('46'))
+  await repositories.remove(await repositories.get('repoId:branch:1234abcd'))
 })

--- a/test/jobs/create-initial-pr.js
+++ b/test/jobs/create-initial-pr.js
@@ -402,7 +402,7 @@ test('create-initial-pr', async t => {
         return {}
       })
 
-    simple.mock(payments, 'getCurrentlyPrivateAndEnabledRepos').returnWith(15)
+    simple.mock(payments, 'getAmountOfCurrentlyPrivateAndEnabledRepos').returnWith(15)
 
     await createInitial({
       repository: { id: '44b' },

--- a/test/jobs/github-event/marketplace_purchase/cancelled.js
+++ b/test/jobs/github-event/marketplace_purchase/cancelled.js
@@ -1,0 +1,57 @@
+const { test, tearDown } = require('tap')
+const dbs = require('../../../../lib/dbs')
+const worker = require('../../../../jobs/github-event/marketplace_purchase/cancelled')
+
+const removeIfExists = async (db, id) => {
+  try {
+    return await db.remove(await db.get(id))
+  } catch (e) {
+    if (e.status !== 404) {
+      throw e
+    }
+  }
+}
+
+test('marketplace canceled', async t => {
+  t.test('change entry in payments database to `free`', async t => {
+    const { payments } = await dbs()
+    await payments.put({
+      _id: '444',
+      plan: 'team'
+    })
+
+    const newJobs = await worker({
+      marketplace_purchase: {
+        account: {
+          type: 'Organization',
+          id: 444,
+          login: 'GitHub'
+        },
+        plan: {
+          id: 9,
+          name: 'Team',
+          description: 'A really, super professional-grade CI solution',
+          monthly_price_in_cents: 9999,
+          yearly_price_in_cents: 11998,
+          price_model: 'flat-rate',
+          unit_name: null,
+          bullets: [
+            'This is the first bullet of the plan',
+            'This is the second bullet of the plan'
+          ]
+        }
+      }
+    })
+
+    t.notOk(newJobs, 'no new job scheduled')
+
+    const payment = await payments.get('444')
+    t.is(payment.plan, 'free', 'plan: free')
+    t.end()
+  })
+})
+
+tearDown(async () => {
+  const { payments } = await dbs()
+  await removeIfExists(payments, '444')
+})

--- a/test/jobs/github-event/marketplace_purchase/cancelled.js
+++ b/test/jobs/github-event/marketplace_purchase/cancelled.js
@@ -1,16 +1,7 @@
 const { test, tearDown } = require('tap')
 const dbs = require('../../../../lib/dbs')
 const worker = require('../../../../jobs/github-event/marketplace_purchase/cancelled')
-
-const removeIfExists = async (db, id) => {
-  try {
-    return await db.remove(await db.get(id))
-  } catch (e) {
-    if (e.status !== 404) {
-      throw e
-    }
-  }
-}
+const removeIfExists = require('../../../remove-if-exists.js')
 
 test('marketplace canceled', async t => {
   t.test('change entry in payments database to `free`', async t => {

--- a/test/jobs/github-event/marketplace_purchase/changed.js
+++ b/test/jobs/github-event/marketplace_purchase/changed.js
@@ -1,16 +1,7 @@
 const { test, tearDown } = require('tap')
 const dbs = require('../../../../lib/dbs')
 const worker = require('../../../../jobs/github-event/marketplace_purchase/changed')
-
-const removeIfExists = async (db, id) => {
-  try {
-    return await db.remove(await db.get(id))
-  } catch (e) {
-    if (e.status !== 404) {
-      throw e
-    }
-  }
-}
+const removeIfExists = require('../../../remove-if-exists.js')
 
 test('marketplace changed', async t => {
   t.test('change entry in payments database', async t => {

--- a/test/jobs/github-event/marketplace_purchase/changed.js
+++ b/test/jobs/github-event/marketplace_purchase/changed.js
@@ -1,0 +1,57 @@
+const { test, tearDown } = require('tap')
+const dbs = require('../../../../lib/dbs')
+const worker = require('../../../../jobs/github-event/marketplace_purchase/changed')
+
+const removeIfExists = async (db, id) => {
+  try {
+    return await db.remove(await db.get(id))
+  } catch (e) {
+    if (e.status !== 404) {
+      throw e
+    }
+  }
+}
+
+test('marketplace changed', async t => {
+  t.test('change entry in payments database', async t => {
+    const { payments } = await dbs()
+    await payments.put({
+      _id: '444',
+      plan: 'team'
+    })
+
+    const newJobs = await worker({
+      marketplace_purchase: {
+        account: {
+          type: 'Organization',
+          id: 444,
+          login: 'GitHub'
+        },
+        plan: {
+          id: 9,
+          name: 'Open Source',
+          description: 'A really, super professional-grade CI solution',
+          monthly_price_in_cents: 9999,
+          yearly_price_in_cents: 11998,
+          price_model: 'flat-rate',
+          unit_name: null,
+          bullets: [
+            'This is the first bullet of the plan',
+            'This is the second bullet of the plan'
+          ]
+        }
+      }
+    })
+
+    t.notOk(newJobs, 'no new job scheduled')
+
+    const payment = await payments.get('444')
+    t.is(payment.plan, 'opensource', 'plan: opensource')
+    t.end()
+  })
+})
+
+tearDown(async () => {
+  const { payments } = await dbs()
+  await removeIfExists(payments, '444')
+})

--- a/test/jobs/github-event/marketplace_purchase/purchased.js
+++ b/test/jobs/github-event/marketplace_purchase/purchased.js
@@ -1,0 +1,228 @@
+const { test, tearDown } = require('tap')
+const nock = require('nock')
+const dbs = require('../../../../lib/dbs')
+const worker = require('../../../../jobs/github-event/marketplace_purchase/purchased')
+
+const removeIfExists = async (db, id) => {
+  try {
+    return await db.remove(await db.get(id))
+  } catch (e) {
+    if (e.status !== 404) {
+      throw e
+    }
+  }
+}
+
+nock.disableNetConnect()
+nock.enableNetConnect('localhost')
+
+test('marketplace purchased', async t => {
+  t.test('create entry in payments database', async t => {
+    const { payments } = await dbs()
+
+    const newJobs = await worker({
+      marketplace_purchase: {
+        account: {
+          type: 'Organization',
+          id: 444,
+          login: 'GitHub'
+        },
+        plan: {
+          id: 9,
+          name: 'Open Source',
+          description: 'A really, super professional-grade CI solution',
+          monthly_price_in_cents: 9999,
+          yearly_price_in_cents: 11998,
+          price_model: 'flat-rate',
+          unit_name: null,
+          bullets: [
+            'This is the first bullet of the plan',
+            'This is the second bullet of the plan'
+          ]
+        }
+      }
+    })
+
+    t.notOk(newJobs, 'no new job scheduled')
+
+    const payment = await payments.get('444')
+    t.is(payment.plan, 'opensource', 'plan: opensource')
+    t.end()
+  })
+
+  t.test('update entry in payments database from free to github paid', async t => {
+    const { payments } = await dbs()
+    await payments.put({
+      _id: '445',
+      plan: 'free'
+    })
+
+    const newJobs = await worker({
+      'marketplace_purchase': {
+        'account': {
+          'type': 'Organization',
+          'id': 445,
+          'login': 'GitHub'
+        },
+        'plan': {
+          'id': 9,
+          'name': 'Team',
+          'description': 'A really, super professional-grade CI solution',
+          'monthly_price_in_cents': 9999,
+          'yearly_price_in_cents': 11998,
+          'price_model': 'flat-rate',
+          'unit_name': null,
+          'bullets': [
+            'This is the first bullet of the plan',
+            'This is the second bullet of the plan'
+          ]
+        }
+      }
+    })
+
+    t.notOk(newJobs, 'no new job scheduled')
+
+    const payment = await payments.get('445')
+    t.is(payment.plan, 'team', 'plan: team')
+    t.end()
+  })
+
+  t.test('update entry in payments database from free to github free', async t => {
+    const { payments } = await dbs()
+    await payments.put({
+      _id: '446',
+      plan: 'free'
+    })
+
+    const newJobs = await worker({
+      'action': 'purchased',
+      'effective_date': '2017-04-06T02:01:16Z',
+      'marketplace_purchase': {
+        'account': {
+          'type': 'Organization',
+          'id': 446,
+          'login': 'GitHub'
+        },
+        'billing_cycle': 'monthly',
+        'next_billing_date': '2017-05-01T00:00:00Z',
+        'unit_count': null,
+        'plan': {
+          'id': 9,
+          'name': 'Open Source',
+          'description': 'A really, super professional-grade CI solution',
+          'monthly_price_in_cents': 9999,
+          'yearly_price_in_cents': 11998,
+          'price_model': 'flat-rate',
+          'unit_name': null,
+          'bullets': [
+            'This is the first bullet of the plan',
+            'This is the second bullet of the plan'
+          ]
+        }
+      }
+    })
+
+    t.notOk(newJobs, 'no new job scheduled')
+
+    const payment = await payments.get('446')
+    t.is(payment.plan, 'opensource', 'plan: opensource')
+    t.end()
+  })
+
+  t.test('update entry in payments database from stripe to github paid', async t => {
+    const { payments } = await dbs()
+    await payments.put({
+      _id: '447',
+      plan: 'personal',
+      stripeCustomerId: 'cus_abc',
+      stripeItemId: 'si_xyz',
+      stripeSubscriptionId: 'sub_abcxyz'
+    })
+
+    const newJob = await worker({
+      marketplace_purchase: {
+        account: {
+          type: 'Organization',
+          id: 447,
+          login: 'GitHub'
+        },
+        plan: {
+          id: 9,
+          name: 'Team',
+          description: 'A really, super professional-grade CI solution',
+          monthly_price_in_cents: 9999,
+          yearly_price_in_cents: 11998,
+          price_model: 'flat-rate',
+          unit_name: null,
+          bullets: [
+            'This is the first bullet of the plan',
+            'This is the second bullet of the plan'
+          ]
+        }
+      }
+    })
+
+    t.ok(newJob, 'new job scheduled')
+    t.is(newJob.data.name, 'cancel-stripe-subscription', 'Job is: cancel-stripe-subscription')
+
+    const payment = await payments.get('447')
+    t.is(payment.plan, 'team', 'plan: team')
+    t.end()
+  })
+
+  t.test('update entry in payments database from stripe to github free', async t => {
+    const { payments } = await dbs()
+    await payments.put({
+      _id: '448',
+      plan: 'personal',
+      stripeCustomerId: 'cus_abc',
+      stripeItemId: 'si_xyz',
+      stripeSubscriptionId: 'sub_abcxyz'
+    })
+
+    const newJob = await worker({
+      'action': 'purchased',
+      'effective_date': '2017-04-06T02:01:16Z',
+      'marketplace_purchase': {
+        'account': {
+          'type': 'Organization',
+          'id': 448,
+          'login': 'GitHub'
+        },
+        'billing_cycle': 'monthly',
+        'next_billing_date': '2017-05-01T00:00:00Z',
+        'unit_count': null,
+        'plan': {
+          'id': 9,
+          'name': 'Open Source',
+          'description': 'A really, super professional-grade CI solution',
+          'monthly_price_in_cents': 9999,
+          'yearly_price_in_cents': 11998,
+          'price_model': 'flat-rate',
+          'unit_name': null,
+          'bullets': [
+            'This is the first bullet of the plan',
+            'This is the second bullet of the plan'
+          ]
+        }
+      }
+    })
+
+    t.ok(newJob, 'new job scheduled')
+    t.is(newJob.data.name, 'cancel-stripe-subscription', 'Job is: cancel-stripe-subscription')
+
+    const payment = await payments.get('448')
+    t.is(payment.plan, 'opensource', 'plan: opensource')
+    t.end()
+  })
+})
+
+tearDown(async () => {
+  const { payments } = await dbs()
+
+  await removeIfExists(payments, '444')
+  await removeIfExists(payments, '445')
+  await removeIfExists(payments, '446')
+  await removeIfExists(payments, '447')
+  await removeIfExists(payments, '448')
+})

--- a/test/jobs/github-event/marketplace_purchase/purchased.js
+++ b/test/jobs/github-event/marketplace_purchase/purchased.js
@@ -2,16 +2,7 @@ const { test, tearDown } = require('tap')
 const nock = require('nock')
 const dbs = require('../../../../lib/dbs')
 const worker = require('../../../../jobs/github-event/marketplace_purchase/purchased')
-
-const removeIfExists = async (db, id) => {
-  try {
-    return await db.remove(await db.get(id))
-  } catch (e) {
-    if (e.status !== 404) {
-      throw e
-    }
-  }
-}
+const removeIfExists = require('../../../remove-if-exists.js')
 
 nock.disableNetConnect()
 nock.enableNetConnect('localhost')

--- a/test/jobs/reset.js
+++ b/test/jobs/reset.js
@@ -1,6 +1,7 @@
 const { test } = require('tap')
 const nock = require('nock')
 const worker = require('../../jobs/reset')
+const removeIfExists = require('../remove-if-exists.js')
 
 const dbs = require('../../lib/dbs')
 const timeToWaitAfterTests = 500
@@ -9,16 +10,6 @@ const waitFor = (milliseconds) => {
   return new Promise((resolve) => {
     setTimeout(resolve, milliseconds)
   })
-}
-
-const removeIfExists = async (db, id) => {
-  try {
-    return await db.remove(await db.get(id))
-  } catch (e) {
-    if (e.status !== 404) {
-      throw e
-    }
-  }
 }
 
 nock.disableNetConnect()

--- a/test/jobs/update-payments.js
+++ b/test/jobs/update-payments.js
@@ -62,12 +62,12 @@ test('update-payments', async t => {
     t.notOk(newJobs, 'no new jobs scheduled')
   })
 
-  t.test('ignore if stripeItemId is missing', async t => {
+  t.test('ignore if stripeSubscriptionId is missing', async t => {
     const worker = proxyquire('../../jobs/update-payments', {
       '../lib/payments': {
         getActiveBilling: async () => {
           return {
-            plan: 'beta'
+            plan: 'org'
           }
         }
       },

--- a/test/jobs/update-payments.js
+++ b/test/jobs/update-payments.js
@@ -1,5 +1,5 @@
 const { test, tearDown } = require('tap')
-const proxyquire = require('proxyquire').noCallThru()
+const proxyquire = require('proxyquire')
 
 const dbs = require('../../lib/dbs')
 

--- a/test/lib/payments.js
+++ b/test/lib/payments.js
@@ -1,6 +1,8 @@
 const { test, tearDown } = require('tap')
+const proxyquire = require('proxyquire')
+
 const dbs = require('../../lib/dbs')
-const { getActiveBilling, maybeUpdatePaymentsJob, hasBilling } = require(
+const { getActiveBilling, maybeUpdatePaymentsJob, hasStripeBilling, getAccountNeedsMarketplaceUpgrade } = require(
   '../../lib/payments'
 )
 
@@ -20,7 +22,22 @@ test('payments', async t => {
     stripeSubscriptionId: 'stripe124',
     plan: 'org'
   })
-  t.test('getActiveBilling with billing', async t => {
+  await payments.put({
+    _id: '123opensource',
+    plan: 'opensource'
+  })
+  await payments.put({
+    _id: '123team',
+    plan: 'team'
+  })
+  await payments.put({
+    _id: '123business',
+    plan: 'business'
+  })
+
+  /* getActiveBilling */
+
+  t.test('getActiveBilling with billing personal', async t => {
     const billing = await getActiveBilling('123')
     t.equal(billing.stripeSubscriptionId, 'stripe123', 'stripe id')
     t.equal(billing.plan, 'personal', 'plan')
@@ -42,6 +59,21 @@ test('payments', async t => {
     t.notOk(billing)
     t.end()
   })
+  t.test('getActiveBilling with opensource billing', async t => {
+    const billing = await getActiveBilling('123opensource')
+    t.notOk(billing)
+    t.end()
+  })
+  t.test('getActiveBilling with billing team', async t => {
+    const billing = await getActiveBilling('123team')
+    t.equal(billing.plan, 'team', 'plan')
+    t.end()
+  })
+  t.test('getActiveBilling with billing business', async t => {
+    const billing = await getActiveBilling('123business')
+    t.equal(billing.plan, 'business', 'plan')
+    t.end()
+  })
   t.test('throw on missing accountId', async t => {
     try {
       await getActiveBilling()
@@ -52,19 +84,29 @@ test('payments', async t => {
     t.end()
   })
 
-  t.test('hasBilling without billing', async t => {
-    const billing = await hasBilling('000')
+  /* hasStripeBilling */
+
+  t.test('hasStripeBilling without stripe', async t => {
+    const billing = await hasStripeBilling('123team')
     t.notOk(billing)
     t.end()
   })
-  t.test('hasBilling with billing', async t => {
-    const billing = await hasBilling('123')
+  t.test('hasStripeBilling with stripe', async t => {
+    const billing = await hasStripeBilling('123')
     t.ok(billing)
     t.end()
   })
 
+    /* maybeUpdatePaymentsJob */
+
   t.test('maybeUpdatePaymentsJob without billing', async t => {
     const newJob = await maybeUpdatePaymentsJob('000', true)
+    t.notOk(newJob)
+    t.end()
+  })
+
+  t.test('maybeUpdatePaymentsJob without stripe', async t => {
+    const newJob = await maybeUpdatePaymentsJob('123business', true)
     t.notOk(newJob)
     t.end()
   })
@@ -83,6 +125,61 @@ test('payments', async t => {
     })
     t.end()
   })
+
+  /* getAccountNeedsMarketplaceUpgrade */
+
+  t.test('getAccountNeedsMarketplaceUpgrade without billing', async t => {
+    const result = await getAccountNeedsMarketplaceUpgrade('000')
+    t.notOk(result)
+    t.end()
+  })
+
+  t.test('getAccountNeedsMarketplaceUpgrade with `free` plan', async t => {
+    const result = await getAccountNeedsMarketplaceUpgrade('123free')
+    t.notOk(result)
+    t.end()
+  })
+
+  t.test('getAccountNeedsMarketplaceUpgrade with stripe `personal` plan', async t => {
+    const result = await getAccountNeedsMarketplaceUpgrade('123')
+    t.notOk(result)
+    t.end()
+  })
+
+  t.test('getAccountNeedsMarketplaceUpgrade with stripe `org` plan', async t => {
+    const result = await getAccountNeedsMarketplaceUpgrade('123org')
+    t.notOk(result)
+    t.end()
+  })
+
+  t.test('getAccountNeedsMarketplaceUpgrade with `opensource` plan', async t => {
+    const result = await getAccountNeedsMarketplaceUpgrade('123opensource')
+    t.ok(result)
+    t.end()
+  })
+
+  t.test('getAccountNeedsMarketplaceUpgrade with `team` plan and under repo limit', async t => {
+    const result = await getAccountNeedsMarketplaceUpgrade('123team')
+    t.notOk(result)
+    t.end()
+  })
+
+  t.test('getAccountNeedsMarketplaceUpgrade with `team` plan and reached repo limit', async t => {
+    const { getAccountNeedsMarketplaceUpgrade } = proxyquire('../../lib/payments', { // Help! can't get this to be overwritten
+      './getCurrentlyPrivateAndEnabledRepos': async (accountId) => {
+        return 15
+      }
+    })
+    const result = await getAccountNeedsMarketplaceUpgrade('123team')
+    t.ok(result)
+    t.end()
+  })
+
+  t.test('getAccountNeedsMarketplaceUpgrade with stripe `business` plan', async t => {
+    const result = await getAccountNeedsMarketplaceUpgrade('123business')
+    t.notOk(result)
+    t.end()
+  })
 })
 
 tearDown(async () => {
@@ -90,4 +187,7 @@ tearDown(async () => {
   payments.remove(await payments.get('123'))
   payments.remove(await payments.get('123free'))
   payments.remove(await payments.get('123org'))
+  payments.remove(await payments.get('123opensource'))
+  payments.remove(await payments.get('123team'))
+  payments.remove(await payments.get('123business'))
 })

--- a/test/lib/payments.js
+++ b/test/lib/payments.js
@@ -1,5 +1,5 @@
 const { test, tearDown } = require('tap')
-const proxyquire = require('proxyquire')
+const simple = require('simple-mock')
 
 const dbs = require('../../lib/dbs')
 const { getActiveBilling, maybeUpdatePaymentsJob, hasStripeBilling, getAccountNeedsMarketplaceUpgrade } = require(
@@ -165,12 +165,11 @@ test('payments', async t => {
   })
 
   t.test('getAccountNeedsMarketplaceUpgrade with `team` plan and reached repo limit', async t => {
-    const { getAccountNeedsMarketplaceUpgrade } = proxyquire('../../lib/payments', { // Help! can't get this to be overwritten
-      './getCurrentlyPrivateAndEnabledRepos': async (accountId) => {
-        return 15
-      }
-    })
+    const payments = require('../../lib/payments')
+    simple.mock(payments, 'getCurrentlyPrivateAndEnabledRepos').resolveWith(15)
     const result = await getAccountNeedsMarketplaceUpgrade('123team')
+    simple.restore()
+
     t.ok(result)
     t.end()
   })

--- a/test/lib/payments.js
+++ b/test/lib/payments.js
@@ -2,7 +2,7 @@ const { test, tearDown } = require('tap')
 const simple = require('simple-mock')
 
 const dbs = require('../../lib/dbs')
-const { getActiveBilling, maybeUpdatePaymentsJob, hasStripeBilling, getAccountNeedsMarketplaceUpgrade, getCurrentlyPrivateAndEnabledRepos } = require(
+const { getActiveBilling, maybeUpdatePaymentsJob, hasStripeBilling, getAccountNeedsMarketplaceUpgrade, getAmountOfCurrentlyPrivateAndEnabledRepos } = require(
   '../../lib/payments'
 )
 
@@ -158,16 +158,16 @@ test('payments', async t => {
     t.end()
   })
 
-  /* getCurrentlyPrivateAndEnabledRepos */
+  /* getAmountOfCurrentlyPrivateAndEnabledRepos */
 
-  t.test('getCurrentlyPrivateAndEnabledRepos with no Repos', async t => {
-    const result = await getCurrentlyPrivateAndEnabledRepos('123')
+  t.test('getAmountOfCurrentlyPrivateAndEnabledRepos with no Repos', async t => {
+    const result = await getAmountOfCurrentlyPrivateAndEnabledRepos('123')
     t.equal(result, 0, '0 private and enabled repos')
     t.end()
   })
 
-  t.test('getCurrentlyPrivateAndEnabledRepos with one Repo', async t => {
-    const result = await getCurrentlyPrivateAndEnabledRepos('123team')
+  t.test('getAmountOfCurrentlyPrivateAndEnabledRepos with one Repo', async t => {
+    const result = await getAmountOfCurrentlyPrivateAndEnabledRepos('123team')
     t.equal(result, 1, '1 private and enabled repo')
     t.end()
   })
@@ -212,7 +212,7 @@ test('payments', async t => {
 
   t.test('getAccountNeedsMarketplaceUpgrade with `team` plan and reached repo limit', async t => {
     const payments = require('../../lib/payments')
-    simple.mock(payments, 'getCurrentlyPrivateAndEnabledRepos').resolveWith(15)
+    simple.mock(payments, 'getAmountOfCurrentlyPrivateAndEnabledRepos').resolveWith(15)
     const result = await getAccountNeedsMarketplaceUpgrade('123team')
     simple.restore()
 

--- a/test/remove-if-exists.js
+++ b/test/remove-if-exists.js
@@ -1,0 +1,9 @@
+module.exports = async function (db, id) {
+  try {
+    return await db.remove(await db.get(id))
+  } catch (e) {
+    if (e.status !== 404) {
+      throw e
+    }
+  }
+}


### PR DESCRIPTION
Background: with the Github Marketplace plans we can't do a 'pay as you go' model. We will have an 'opensource' plan (equals the 'free' plan), a 'team' plan which includes 15 private repos and a 'business' plan which includes unlimited everything.
so we need to:

- [x] ~~`create-initial-branch`: not 'silently' enable private Repos~~ _doesn't matter as create-version-branch checks again if payment is there_
- [x] set the 'payment required' status on private repos for plans: _free_ (already happening), _opensource_ and _team_ with more than 15 private repos.
  - [x] `create-initial-pr`
  -  [x] `pull_request/opened` (= user created  initial pr)
- [x] do not trigger PR from `create-version-branch`  if payment is required
- [x] do not trigger the `update-payments` job for non-stripe users
- [x] cancel Stripe subscription if Stripe users buy via Github Marketplace
- [x] add the new Github Marketplace hooks
  - [x] `purchased`
  - [x] `changed`
  - [x] `cancelled`

**Before we can deploy to prod:**

- [x] update gk-account to not show CC stuff to GK users.