### PR TITLE
Handle load spikes more gracefully

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,6 +27,9 @@ require('./lib/rollbar')
   const conn = await amqp.connect(env.AMQP_URL)
   const channel = await conn.createChannel()
 
+  // only allow 128 items to pile up
+  channel.prefetch(128)
+
   // 5 different prios because order matters
   // e.g. always sync before everything else
   // or always uninstall integrations before installing

--- a/index.js
+++ b/index.js
@@ -81,10 +81,10 @@ require('./lib/rollbar')
 
   async function consume (job) {
     const data = JSON.parse(job.content.toString())
-    // const jobsWithoutOwners = ['registry-change', 'stripe-event', 'schedule-stale-initial-pr-reminders', 'reset', 'cancel-stripe-subscription']
-    // if (jobsWithoutOwners.includes(data.name) || data.type === 'marketplace_purchase') {
-    return queueJob(data.name, job)
-    // }
+    const jobsWithoutOwners = ['registry-change', 'stripe-event', 'schedule-stale-initial-pr-reminders', 'reset', 'cancel-stripe-subscription']
+    if (jobsWithoutOwners.includes(data.name) || data.type === 'marketplace_purchase') {
+      return queueJob(data.name, job)
+    }
 
     // let queueId = Number(data.accountId) ||
     //   _.get(data, 'repository.owner.id') ||

--- a/index.js
+++ b/index.js
@@ -27,9 +27,6 @@ require('./lib/rollbar')
   const conn = await amqp.connect(env.AMQP_URL)
   const channel = await conn.createChannel()
 
-  // only allow 64 items to pile up
-  channel.prefetch(64)
-
   // 5 different prios because order matters
   // e.g. always sync before everything else
   // or always uninstall integrations before installing


### PR DESCRIPTION
Revert hotfixes and re-add permanent solution.

Upped to 128 concurrent jobs because of observed queue-drain speed vs. ops resource usage.