### PR TITLE
Fix/lockfile handling

### DIFF
--- a/jobs/create-version-branch.js
+++ b/jobs/create-version-branch.js
@@ -78,12 +78,11 @@ module.exports = async function (
     return
   }
 
-  // Some uses may want to use project lockfiles for version pinning, in this case, we shouldn’t update
-  // the lockfiles either
+  // Some users may want to keep the legacy behaviour where all lockfiles are only ever updated on out-of-range updates.
   const config = getConfig(repository)
-  const onlyUpdateLockfilesIfOutOfRange = _.get(config, 'onlyUpdateLockfilesIfOutOfRange') === true
+  const onlyUpdateLockfilesIfOutOfRange = _.get(config, 'lockfiles.outOfRangeUpdatesOnly') === true
   if (satisfies && hasProjectLockFile && onlyUpdateLockfilesIfOutOfRange) {
-    log.info('exited: dependency satisfies semver & repository has a project lockfile (*-lock type) & onlyUpdateLockfilesIfOutOfRange is true')
+    log.info('exited: dependency satisfies semver & repository has a project lockfile (*-lock type) & lockfiles.outOfRangeUpdatesOnly is true')
     return
   }
 

--- a/jobs/create-version-branch.js
+++ b/jobs/create-version-branch.js
@@ -76,9 +76,9 @@ module.exports = async function (
   // Some uses may want to use project lockfiles for version pinning, in this case, we shouldn’t update
   // the lockfiles either
   const config = getConfig(repository)
-  const treatLockfilesAsPins = _.get(config, 'treatLockfilesAsPins') === true
-  if (satisfies && hasProjectLockFile && treatLockfilesAsPins) {
-    log.info('exited: dependency satisfies semver & repository has a project lockfile (*-lock type) & treatLockfilesAsPins is true')
+  const onlyUpdateLockfilesIfOutOfRange = _.get(config, 'onlyUpdateLockfilesIfOutOfRange') === true
+  if (satisfies && hasProjectLockFile && onlyUpdateLockfilesIfOutOfRange) {
+    log.info('exited: dependency satisfies semver & repository has a project lockfile (*-lock type) & onlyUpdateLockfilesIfOutOfRange is true')
     return
   }
 

--- a/jobs/create-version-branch.js
+++ b/jobs/create-version-branch.js
@@ -41,19 +41,24 @@ module.exports = async function (
   const log = Log({logsDb: logs, accountId, repoSlug: repository.fullName, context: 'create-version-branch'})
   log.info('started', {dependency, type, version, oldVersion})
   const satisfies = semver.satisfies(version, oldVersion)
-  /*
 
-  Shrinkwrap should behave differently from regular lockfiles:
+  // Shrinkwrap should behave differently from regular lockfiles:
+  //
+  // If an npm-shrinkwrap.json exists, we bail if semver is satisfied and continue
+  // if not. For the other two types of lockfiles (package-lock and yarn-lock),
+  // we will in future check if gk-lockfile is found in the repo’s dev-dependencies,
+  // if it is, Greenkeeper will continue (and the lockfiles will get updated),
+  // if not, we bail as before and nothing happens (because without gk-lockfile,
+  // the CI build wouldn‘t install anything new anyway).
+  //
+  // Variable name explanations:
+  // - moduleLogFile: Lockfiles that get published to npm and that influence what
+  //   gets installed on a user’s machine, such as `npm-shrinkwrap.json`.
+  // - projectLockFile: lockfiles that don’t get published to npm and have no
+  //   influence on the users’ dependency trees, like package-lock and yarn-lock
+  //
+  // See this issue for details: https://github.com/greenkeeperio/greenkeeper/issues/506
 
-  If an npm-shrinkwrap.json exists, we bail if semver is satisfied and continue if not. For the other two types of lockfiles (package-lock and yarn-lock), we will in future check if gk-lockfile is found in the repo’s dev-dependencies, if it is, Greenkeeper will continue (and the lockfiles will get updated), if not, we bail as before and nothing happens (because without gk-lockfile, the CI build wouldn‘t install anything new anyway).
-
-  Variable name explanations:
-  - moduleLogFile: Lockfiles that get published to npm and influence what gets installed on a user’s machine, shrinkwrap, for example.
-  - projectLockFile: lockfiles that don’t get published to npm and have no influence on the users’ dependency trees, like package-lock and yarn-lock
-
-  See this issue for details: https://github.com/greenkeeperio/greenkeeper/issues/506
-
-  */
   const moduleLockFiles = ['npm-shrinkwrap.json']
   const projectLockFiles = ['package-lock.json', 'yarn.lock']
   const hasModuleLockFile = _.some(_.pick(repository.files, moduleLockFiles))

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "proxyquire": "^1.7.10",
     "simple-mock": "^0.8.0",
     "standard": "^10.0.2",
-    "tap": "^10.0.1"
+    "tap": "^10.7.3"
   },
   "engines": {
     "node": ">=7.6"

--- a/test/jobs/create-version-branch.js
+++ b/test/jobs/create-version-branch.js
@@ -658,7 +658,9 @@ test('create-version-branch', async t => {
             'greenkeeper-lockfile': '1.1.1'
           },
           greenkeeper: {
-            'onlyUpdateLockfilesIfOutOfRange': true
+            lockfiles: {
+              outOfRangeUpdatesOnly: true
+            }
           }
         }
       }


### PR DESCRIPTION
## Fixes:
- handles `shrinkwrap.json` differently than the other package files, for the reasoning outlined in [this issue](https://github.com/greenkeeperio/greenkeeper/issues/506).

In short: 

> If an npm-shrinkwrap.json exists, we do the same thing as before: bail if semver is satisfied and continue if not. For the other two types of lockfiles (package-lock and yarn-lock), we will in future check if gk-lockfile is found in the repo’s dev-dependencies, if it is, Greenkeeper will continue (and the lockfiles will get updated), if not, we bail as before and nothing happens (because without gk-lockfile, the CI build wouldn‘t install anything new anyway).