### PR TITLE
github -> @octokit/rest

### DIFF
--- a/lib/github.js
+++ b/lib/github.js
@@ -44,7 +44,6 @@ if (process.env.GITHUB_HOST) {
 
 module.exports = options => new Github(
   _.defaultsDeep(options || {}, githubHost, {
-    Promise: require('bluebird'),
     headers: {
       'User-Agent': 'Greenkeeper'
     }

--- a/lib/github.js
+++ b/lib/github.js
@@ -1,33 +1,39 @@
 const url = require('url')
 
 const _ = require('lodash')
-const { promisify } = require('bluebird')
 const promiseRetry = require('promise-retry')
 
-function ghRetry (ghapi) {
-  const httpSend = ghapi.prototype.httpSend
-  ghapi.prototype.httpSend = function (msg, block, callback) {
-    const send = promisify(httpSend.bind(this, msg, block))
-    promiseRetry(retry => {
-      return send().catch(err => {
-        const type = err.code || err.message
+function ghRetry (octokit) {
+  octokit.hook.error('request', (error, options) => {
+    const type = error.code || error.message
+    if (!['ETIMEDOUT', 'ECONNREFUSED', 'ECONNRESET', 'ESOCKETTIMEDOUT'].includes(type)) {
+      throw error
+    }
+
+    return promiseRetry(retry => {
+      return octokitRequest(options).catch(error => {
+        const type = error.code || error.message
         if (!['ETIMEDOUT', 'ECONNREFUSED', 'ECONNRESET', 'ESOCKETTIMEDOUT'].includes(type)) {
-          throw err
+          throw error
         }
 
-        retry(err)
+        retry(error)
       })
     }, {
       retries: 5,
       minTimeout: 3000
     })
-    .then(res => callback(null, res))
-    .catch(callback)
-  }
-  return ghapi
+  })
 }
 
-const Github = ghRetry(require('github'))
+const Octokit = require('@octokit/rest')
+const octokitRequest = require('@octokit/rest/lib/request')
+const Github = function (options) {
+  const octokit = new Octokit(options)
+  octokit.plugin(ghRetry)
+
+  return octokit
+}
 
 const githubHost = {}
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "couchdb-bootstrap": "^1.14.0",
     "envalid": "^4.0.1",
     "escape-string-regexp": "^1.0.5",
-    "github": "^12.0.1",
+    "github": "^13.1.0",
     "github-url-from-git": "^1.4.0",
     "gk-log": "1.2.0",
     "hot-shots": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@greenkeeper/jobs",
   "version": "0.0.0-development",
   "dependencies": {
+    "@octokit/rest": "14.0.2",
     "amqplib": "^0.5.0",
     "bluebird": "^3.4.6",
     "catbox": "^7.1.3",
@@ -9,7 +10,6 @@
     "couchdb-bootstrap": "^1.14.0",
     "envalid": "^4.0.1",
     "escape-string-regexp": "^1.0.5",
-    "github": "^13.1.0",
     "github-url-from-git": "^1.4.0",
     "gk-log": "1.2.0",
     "hot-shots": "^4.3.0",

--- a/test/jobs/github-event/installation/created.js
+++ b/test/jobs/github-event/installation/created.js
@@ -13,7 +13,7 @@ test('github-event installation created', async t => {
     })
     .get('/rate_limit')
     .reply(200, {})
-    .get('/installation/repositories')
+    .get('/installation/repositories?per_page=100')
     .reply('200', {
       repositories: [
         {
@@ -22,9 +22,9 @@ test('github-event installation created', async t => {
           private: true
         }
       ]}, {
-        Link: '<https://api.github.com/installation/repositories?page=2>; rel="next"'
+        Link: '<https://api.github.com/installation/repositories?per_page=100&page=2>; rel="next"'
       })
-    .get('/installation/repositories?page=2')
+    .get('/installation/repositories?per_page=100&page=2')
     .reply('200', {
       repositories: [
         {

--- a/test/lib/github.js
+++ b/test/lib/github.js
@@ -1,11 +1,23 @@
+const nock = require('nock')
+const simple = require('simple-mock')
 const { test } = require('tap')
 
-test('parse github host', t => {
-  process.env.GITHUB_HOST = 'https://enterprise.github/api/v3/'
+test('parse github host', async t => {
+  nock('https://enterprise.github')
+    .get('/api/v3/repos/greenkeeperio/greenkeeper')
+    .reply(200, {})
+
+  simple.mock(process.env, 'GITHUB_HOST', 'https://enterprise.github/api/v3/')
+
   const Github = require('../../lib/github')
   const github = Github()
-  t.is(github.config.protocol, 'https')
-  t.is(github.config.host, 'enterprise.github')
-  t.is(github.config.pathPrefix, '/api/v3')
+
+  try {
+    await github.repos.get({owner: 'greenkeeperio', repo: 'greenkeeper'})
+  } catch (error) {
+    t.error(error)
+  }
+
+  simple.restore()
   t.end()
 })


### PR DESCRIPTION
I used Greenkeeper’s test suite to make sure there were no regressions and it helped greately. These are the changes to make it work with the new @octokit/rest package.

Greenkeeper used undocumented APIs before and is now using experimental APIs that will become public in future, so I pinned the version for now. I’m also thinking how to implement retry-logic more elegantly and as a generic plugin for everyone to use, maybe make it even a core plugin of `@rest/octokit` itself