### PR TITLE
chore(badges): make badge host configurable via environment

### DIFF
--- a/jobs/create-initial-branch.js
+++ b/jobs/create-initial-branch.js
@@ -144,10 +144,10 @@ module.exports = async function ({ repositoryId }) {
   const badgesTokenMaybe = repoDoc.private
     ? `?token=${tokenHash}&ts=${Date.now()}`
     : ''
-  const badgeUrl = `https://badges.greenkeeper.io/${slug}.svg${badgesTokenMaybe}`
+  const badgeUrl = `https://${env.BADGES_HOST}/${slug}.svg${badgesTokenMaybe}`
   log.info('badge: url', {badgeUrl})
 
-  const privateBadgeRegex = /https:\/\/badges\.(staging\.)?greenkeeper\.io\/.+?\.svg\?token=\w+(&ts=\d+)?/
+  const privateBadgeRegex = new RegExp(`https://${env.BADGES_HOST}.+?.svg\\?token=\\w+(&ts=\\d+)?`)
 
   let badgeAlreadyAdded = false
   const transforms = [
@@ -187,7 +187,7 @@ module.exports = async function ({ repositoryId }) {
 
         badgeAlreadyAdded = _.includes(
           readme,
-          'https://badges.greenkeeper.io/'
+          `https://${env.BADGES_HOST}/`
         )
         if (!repoDoc.private && badgeAlreadyAdded) {
           log.info('badge: Repository already has badge')

--- a/lib/env.js
+++ b/lib/env.js
@@ -29,6 +29,7 @@ module.exports = envalid.cleanEnv(process.env, {
   NPM_REGISTRY: url({ default: 'https://registry.npmjs.org/' }),
   GITHUB_URL: url({ default: 'https://github.com' }),
   BADGES_SECRET: str({ devDefault: 'badges-secret' }),
+  BADGES_HOST: str({default: 'badges.greenkeeper.io'}),
   NPMHOOKS_SECRET: str({ devDefault: 'make-secrets-great-again' }),
   STRIPE_SECRET_KEY: str({ devDefault: 'stripe-token' }),
   IS_ENTERPRISE: bool({ default: false }),


### PR DESCRIPTION
This allows us to configure the host for our badges service. This fixes badge creation for staging (once we adapt the environment variable there and restart the service) and allows us to work in GKE environments.