### PR TITLE
feat(config): add the ability to customize commit messages

### DIFF
--- a/jobs/create-initial-branch.js
+++ b/jobs/create-initial-branch.js
@@ -15,6 +15,7 @@ const env = require('../lib/env')
 const getRangedVersion = require('../lib/get-ranged-version')
 const dbs = require('../lib/dbs')
 const getConfig = require('../lib/get-config')
+const getMessage = require('../lib/get-message')
 const createBranch = require('../lib/create-branch')
 const statsd = require('../lib/statsd')
 const { updateRepoDoc } = require('../lib/repository-docs')
@@ -153,7 +154,7 @@ module.exports = async function ({ repositoryId }) {
   const transforms = [
     {
       path: 'package.json',
-      message: 'chore(package): update dependencies',
+      message: getMessage(config.commitMessages, 'initialDependencies'),
       transform: oldPkg => {
         const oldPkgParsed = JSON.parse(oldPkg)
         const inplace = jsonInPlace(oldPkg)
@@ -168,13 +169,13 @@ module.exports = async function ({ repositoryId }) {
     },
     {
       path: '.travis.yml',
-      message: 'chore(travis): whitelist greenkeeper branches',
+      message: getMessage(config.commitMessages, 'initialBranches'),
       transform: raw => travisTransform(config, raw)
     },
     {
       path: 'README.md',
       create: true,
-      message: 'docs(readme): add Greenkeeper badge',
+      message: getMessage(config.commitMessages, 'initialBadge'),
       transform: (readme, path) => {
         // TODO: empty readme, no image support
         const ext = extname(path).slice(1)

--- a/jobs/create-version-branch.js
+++ b/jobs/create-version-branch.js
@@ -5,6 +5,7 @@ const Log = require('gk-log')
 
 const dbs = require('../lib/dbs')
 const getConfig = require('../lib/get-config')
+const getMessage = require('../lib/get-message')
 const getInfos = require('../lib/get-infos')
 const getRangedVersion = require('../lib/get-ranged-version')
 const createBranch = require('../lib/create-branch')
@@ -139,17 +140,17 @@ module.exports = async function (
   )
   log.info('database: found open PR for this dependency', {openPR})
 
-  const commitMessageScope = !satisfies && type === 'dependencies'
-    ? 'fix'
-    : 'chore'
-  let commitMessage = `${commitMessageScope}(package): update ${dependency} to version ${version}`
-
+  const commitMessageKey = !satisfies && type === 'dependencies'
+    ? 'dependencyUpdate'
+    : 'devDependencyUpdate'
+  const commitMessageValues = { dependency, version }
+  let commitMessage = getMessage(config.commitMessages, commitMessageKey, commitMessageValues)
   if (!satisfies && openPR) {
     await upsert(repositories, openPR._id, {
       comments: [...(openPR.comments || []), version]
     })
 
-    commitMessage += `\n\nCloses #${openPR.number}`
+    commitMessage += getMessage(config.commitMessages, 'closes', {number: openPR.number})
   }
   log.info('commit message created', {commitMessage})
 

--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -6,12 +6,25 @@ module.exports = repository => {
     ['packages', 'package.json', 'greenkeeper'],
     {}
   )
+  /* eslint-disable no-template-curly-in-string */
   return Object.assign(
     {
       label: 'greenkeeper',
       branchPrefix: 'greenkeeper/',
-      ignore: []
+      ignore: [],
+      commitMessages: {
+        initialBadge: 'docs(readme): add Greenkeeper badge',
+        initialDependencies: 'chore(package): update dependencies',
+        initialBranches: 'chore(travis): whitelist greenkeeper branches',
+        dependencyUpdate: 'fix(package): update ${dependency} to version ${version}',
+        devDependencyUpdate: 'chore(package): update ${dependency} to version ${version}',
+        dependencyPin: 'fix: pin ${dependency} to ${oldVersion}',
+        devDependencyPin: 'chore: pin ${dependency} to ${oldVersion}',
+        // Conditionally appended to dependencyUpdate
+        closes: '\n\nCloses #${number}'
+      }
     },
     config
   )
+  /* eslint-enable no-template-curly-in-string */
 }

--- a/lib/get-message.js
+++ b/lib/get-message.js
@@ -1,4 +1,4 @@
-const template = require('es6-template-strings')
+const _ = require('lodash')
 
 module.exports = async function (commitMessages, key, values) {
   if (!Object.prototype.hasOwnProperty.call(commitMessages, key)) {
@@ -7,5 +7,5 @@ module.exports = async function (commitMessages, key, values) {
 
   const templateValues = Object.assign({}, values)
 
-  return template(commitMessages[key], templateValues)
+  return _.template(commitMessages[key])(templateValues)
 }

--- a/lib/get-message.js
+++ b/lib/get-message.js
@@ -1,0 +1,11 @@
+const template = require('es6-template-strings')
+
+module.exports = async function (commitMessages, key, values) {
+  if (!Object.prototype.hasOwnProperty.call(commitMessages, key)) {
+    throw new Error(`Unknown message key '${key}'`)
+  }
+
+  const templateValues = Object.assign({}, values)
+
+  return template(commitMessages[key], templateValues)
+}

--- a/lib/get-message.js
+++ b/lib/get-message.js
@@ -1,6 +1,6 @@
 const _ = require('lodash')
 
-module.exports = async function (commitMessages, key, values) {
+module.exports = function (commitMessages, key, values) {
   if (!Object.prototype.hasOwnProperty.call(commitMessages, key)) {
     throw new Error(`Unknown message key '${key}'`)
   }

--- a/lib/open-issue.js
+++ b/lib/open-issue.js
@@ -5,6 +5,7 @@ const dbs = require('./dbs')
 const createBranch = require('./create-branch')
 const updatedAt = require('./updated-at')
 const getConfig = require('./get-config')
+const getMessage = require('./get-message')
 const statsd = require('./statsd')
 const githubQueue = require('./github-queue')
 
@@ -31,7 +32,7 @@ module.exports = async function (
 ) {
   const { repositories } = await dbs()
   const repoDoc = await repositories.get(repositoryId)
-  const { branchPrefix, label } = getConfig(repoDoc)
+  const { branchPrefix, label, commitMessages } = getConfig(repoDoc)
 
   const body = issueContent({
     dependencyLink,
@@ -64,6 +65,9 @@ module.exports = async function (
     return parsed.toString()
   }
 
+  const messageValues = { dependency, oldVersion: oldVersionResolved }
+  const messageKey = dependencyType === 'devDependencies' ? 'dependencyPin' : 'devDependencyPin'
+
   const sha = await createBranch({
     installationId,
     owner,
@@ -72,7 +76,7 @@ module.exports = async function (
     newBranch,
     path: 'package.json',
     transform,
-    message: `${dependencyType === 'devDependencies' ? 'chore' : 'fix'}: pin ${dependency} to ${oldVersionResolved}`
+    message: getMessage(commitMessages, messageKey, messageValues)
   })
 
   await repositories.bulkDocs(

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "catbox-memory": "^2.0.4",
     "couchdb-bootstrap": "^1.14.0",
     "envalid": "^4.0.1",
-    "es6-template-strings": "^2.0.1",
     "escape-string-regexp": "^1.0.5",
     "github-url-from-git": "^1.4.0",
     "gk-log": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "catbox-memory": "^2.0.4",
     "couchdb-bootstrap": "^1.14.0",
     "envalid": "^4.0.1",
+    "es6-template-strings": "^2.0.1",
     "escape-string-regexp": "^1.0.5",
     "github-url-from-git": "^1.4.0",
     "gk-log": "1.2.0",

--- a/test/lib/get-message.js
+++ b/test/lib/get-message.js
@@ -1,0 +1,53 @@
+const { test } = require('tap')
+const getMessage = require('../../lib/get-message')
+
+/* eslint-disable no-template-curly-in-string */
+
+test('get default commit messages', t => {
+  const commitMessages = {
+    initialBadge: 'docs(readme): add Greenkeeper badge',
+    initialDependencies: 'chore(package): update dependencies',
+    initialBranches: 'chore(travis): whitelist greenkeeper branches',
+    dependencyUpdate: 'fix(package): update ${dependency} to version ${version}',
+    devDependencyUpdate: 'chore(package): update ${dependency} to version ${version}',
+    dependencyPin: 'fix: pin ${dependency} to ${oldVersion}',
+    devDependencyPin: 'chore: pin ${dependency} to ${oldVersion}',
+    closes: '\n\nCloses #${number}'
+  }
+  const values = {
+    dependency: 'foo',
+    version: 'bar',
+    oldVersion: 'rab',
+    number: 42
+  }
+  const expected = {
+    initialBadge: 'docs(readme): add Greenkeeper badge',
+    initialDependencies: 'chore(package): update dependencies',
+    initialBranches: 'chore(travis): whitelist greenkeeper branches',
+    dependencyUpdate: 'fix(package): update foo to version bar',
+    devDependencyUpdate: 'chore(package): update foo to version bar',
+    dependencyPin: 'fix: pin foo to rab',
+    devDependencyPin: 'chore: pin foo to rab',
+    closes: '\n\nCloses #42'
+  }
+
+  t.plan(Object.keys(commitMessages).length)
+  t.is(getMessage(commitMessages, 'initialBadge'), expected.initialBadge)
+  t.is(getMessage(commitMessages, 'initialDependencies'), expected.initialDependencies)
+  t.is(getMessage(commitMessages, 'initialBranches'), expected.initialBranches)
+  t.is(getMessage(commitMessages, 'dependencyUpdate', values), expected.dependencyUpdate)
+  t.is(getMessage(commitMessages, 'devDependencyUpdate', values), expected.devDependencyUpdate)
+  t.is(getMessage(commitMessages, 'dependencyPin', values), expected.dependencyPin)
+  t.is(getMessage(commitMessages, 'devDependencyPin', values), expected.devDependencyPin)
+  t.is(getMessage(commitMessages, 'closes', values), expected.closes)
+})
+
+test("throws when it doesn't know a message", t => {
+  const commitMessages = {
+    foo: '42'
+  }
+  const message = "Unknown message key 'bar'"
+
+  t.plan(1)
+  t.throws(() => getMessage(commitMessages, 'bar'), message)
+})


### PR DESCRIPTION
Add configuration options allowing Greenkeeper's commit message format to be customized as the user desires. These are handled exactly like other configuration options, as a `commitMessages` key in `package.json`. Some messages support data coming in, the format for this follows JavaScript's template literals.

This will allow Greenkeeper to fit in with any custom commit message format that a project requires, instead of forcing the conventional-commit style.

Within `package.json` the following keys are used as the default values:
```json
{
  "greenkeeper": {
    "commitMessages": {
      "initialBadge": "docs(readme): add Greenkeeper badge",
      "initialDependencies": "chore(package): update dependencies",
      "initialBranches": "chore(travis): whitelist greenkeeper branches",
      "dependencyUpdate": "fix(package): update ${dependency} to version ${version}",
      "devDependencyUpdate": "chore(package): update ${dependency} to version ${version}",
      "dependencyPin": "fix: pin ${dependency} to ${oldVersion}",
      "devDependencyPin": "chore: pin ${dependency} to ${oldVersion}",
      "closes": "\n\nCloses #${number}"
    }
  }
}
```
_Note: `closes` is somewhat special in that it is conditionally appended to (dev)`dependencyUpdate` and doesn't get used on its own._

The values within `${}` for each message are passed in from the appropriate places within the code, they can be omitted, but the variable names can't be changed from the configuration.

* `dependencyUpdate` and `devDependencyUpdate` support these parameters:
  * `dependency`
  * `version`
* `dependencyPin` and `devDependencyPin` support these parameters:
  * `dependency`
  * `oldVersion`
* `closes` supports a `number` parameter denoting the PR it closes.

As an example usage to have Greenkeeper follow ESLint convention (#608), the following configuration could be used:
```json
{
  "greenkeeper": {
    "commitMessages": {
      "initialBadge": "Docs: Add Greenkeeper badge",
      "initialDependencies": "Upgrade: Update dependencies",
      "initialBranches": "Build: Whitelist greenkeeper branches",
      "dependencyUpdate": "Upgrade: Update ${dependency} to version ${version}",
      "devDependencyUpdate": "Upgrade: Update ${dependency} to version ${version}",
      "dependencyPin": "Fix: Pin ${dependency} to ${oldVersion}",
      "devDependencyPin": "Fix: Pin ${dependency} to ${oldVersion}"
    }
  }
}
```

_Note: Since `closes` is the same as the default, there is no need to specify it here._
_Note: #608 was talking about an "(extended) ESLint" configuration, the above follows [this guide](https://eslint.org/docs/developer-guide/contributing/pull-requests#step-2-make-your-changes)._

Fixes #153.
