### PR TITLE
deep assign user config over default config

### DIFF
--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -7,15 +7,11 @@ module.exports = repository => {
     ['packages', 'package.json', 'greenkeeper'],
     {}
   )
-  /* eslint-disable no-template-curly-in-string */
-  return Object.assign(
-    {
-      label: 'greenkeeper',
-      branchPrefix: 'greenkeeper/',
-      ignore: [],
-      commitMessages: defaultCommitMessages
-    },
-    config
-  )
-  /* eslint-enable no-template-curly-in-string */
+
+  return _.defaultsDeep(config, {
+    label: 'greenkeeper',
+    branchPrefix: 'greenkeeper/',
+    ignore: [],
+    commitMessages: defaultCommitMessages
+  })
 }

--- a/lib/get-message.js
+++ b/lib/get-message.js
@@ -11,12 +11,7 @@ function replaceMessageVariables (message, variables) {
 }
 
 module.exports = function (commitMessages, messageKey, values) {
-  // If no custom messages are defined in the users config
-  // both calls check the same commitMessages Object.
-  // But if the user only defines a subset of the possible custom messages
-  // the error was falsely thrown.
-  if (!Object.prototype.hasOwnProperty.call(commitMessages, messageKey) &&
-  !Object.prototype.hasOwnProperty.call(defaultCommitMessages, messageKey)) {
+  if (!Object.prototype.hasOwnProperty.call(commitMessages, messageKey)) {
     throw new Error(`Unknown message messageKey '${messageKey}'`)
   }
 

--- a/test/lib/get-config.js
+++ b/test/lib/get-config.js
@@ -1,0 +1,67 @@
+const { test } = require('tap')
+const getConfig = require('../../lib/get-config')
+
+/* eslint-disable no-template-curly-in-string */
+
+test('get default config', t => {
+  t.plan(1)
+
+  const repository = {
+    packages: {
+      'package.json': {}
+    }
+  }
+
+  const expected = {
+    label: 'greenkeeper',
+    branchPrefix: 'greenkeeper/',
+    ignore: [],
+    commitMessages: {
+      initialBadge: 'docs(readme): add Greenkeeper badge',
+      initialDependencies: 'chore(package): update dependencies',
+      initialBranches: 'chore(travis): whitelist greenkeeper branches',
+      dependencyUpdate: 'fix(package): update ${dependency} to version ${version}',
+      devDependencyUpdate: 'chore(package): update ${dependency} to version ${version}',
+      dependencyPin: 'fix: pin ${dependency} to ${oldVersion}',
+      devDependencyPin: 'chore: pin ${dependency} to ${oldVersion}',
+      closes: '\n\nCloses #${number}'
+    }
+  }
+
+  t.same(getConfig(repository), expected)
+})
+
+test('get custom commit message', t => {
+  t.plan(1)
+
+  const repository = {
+    packages: {
+      'package.json': {
+        greenkeeper: {
+          commitMessages: {
+            initialBadge: 'HELLO Greenkeeper badge'
+          }
+        }
+      }
+    }
+  }
+
+  const expected = {
+    label: 'greenkeeper',
+    branchPrefix: 'greenkeeper/',
+    ignore: [],
+    commitMessages: {
+      initialBadge: 'HELLO Greenkeeper badge',
+      initialDependencies: 'chore(package): update dependencies',
+      initialBranches: 'chore(travis): whitelist greenkeeper branches',
+      dependencyUpdate: 'fix(package): update ${dependency} to version ${version}',
+      devDependencyUpdate: 'chore(package): update ${dependency} to version ${version}',
+      dependencyPin: 'fix: pin ${dependency} to ${oldVersion}',
+      devDependencyPin: 'chore: pin ${dependency} to ${oldVersion}',
+      closes: '\n\nCloses #${number}'
+    }
+  }
+
+  t.same(getConfig(repository), expected)
+})
+/* eslint-enable no-template-curly-in-string */


### PR DESCRIPTION
the Object.assign would overwrite the commitMessage object completely, causing problems when the user did not define **all** the necessary commit messages.