### PR TITLE
fix: missing release notes

### DIFF
--- a/lib/get-release.js
+++ b/lib/get-release.js
@@ -1,11 +1,15 @@
 const githubQueue = require('./github-queue')
 
 module.exports = async function ({ installationId, owner, repo, version, sha }) {
+  const headers = {
+    accept: 'application/vnd.github.v3.html+json'
+  }
   const ghqueue = githubQueue(installationId)
 
   let result
   try {
     result = await ghqueue.read(github => github.repos.getReleaseByTag({
+      headers,
       owner,
       repo,
       tag: `v${version}`
@@ -13,6 +17,7 @@ module.exports = async function ({ installationId, owner, repo, version, sha }) 
   } catch (err) {
     try {
       result = await ghqueue.read(github => github.repos.getReleaseByTag({
+        headers,
         owner,
         repo,
         tag: `${version}`
@@ -22,6 +27,7 @@ module.exports = async function ({ installationId, owner, repo, version, sha }) 
         const { tag } = await ghqueue.read(github => github.gitdata.getTag({ owner, repo, sha }))
 
         result = await ghqueue.read(github => github.repos.getReleaseByTag({
+          headers,
           owner,
           repo,
           tag
@@ -34,6 +40,8 @@ module.exports = async function ({ installationId, owner, repo, version, sha }) 
 
   if (!result || !result.body_html) return ''
 
+  // We need the redirect because GitHub would parse these as related issues otherwise.
+  // If we did that for a react issue, GK would add 10000 related issues to the react issue :o
   const body = result.body_html.replace(
     /href="https?:\/\/github\.com\//gmi,
     'href="https://urls.greenkeeper.io/'


### PR DESCRIPTION
This should fix the missing release notes. Problem was twofold:
- the `application/vnd.github.v3.html+json` header is required so the `body_html` field is returned, we bail if it isn’t
- the `accept` header key apparently became case sensitive at some point in the past, and we had always used `Accept`, which is now broken