### PR TITLE
feat: ToS notice on issues and prs

### DIFF
--- a/content/fail-issue.js
+++ b/content/fail-issue.js
@@ -18,6 +18,8 @@ ${statuses.map(status => `- ${status.state === 'success' ? '✅' : '❌'} **${st
 `
 
 module.exports = ({version, dependencyLink, owner, repo, head, dependency, oldVersionResolved, dependencyType, statuses, release, diffCommits}) => md`
+☝️ Greenkeeper’s [updated Terms of Service](https://mailchi.mp/ebfddc9880a9/were-updating-our-terms-of-service) will come into effect on April 6th, 2018.
+
 ## Version **${version}** of ${dependencyLink} was just published.
 
 <table>

--- a/content/initial-pr.js
+++ b/content/initial-pr.js
@@ -137,6 +137,8 @@ const mainMessage = ({enabled, depsUpdated}) => {
 
 function prBody ({ghRepo, success, secret, installationId, newBranch, badgeUrl, travisModified, enabled, depsUpdated, accountTokenUrl, files}) {
   return md`
+☝️ Greenkeeper’s [updated Terms of Service](https://mailchi.mp/ebfddc9880a9/were-updating-our-terms-of-service) will come into effect on April 6th, 2018.
+
 Let’s get started with automated dependency management for ${ghRepo.name} :muscle:
 
 ${hasLockFileText(files)}

--- a/content/update-pr.js
+++ b/content/update-pr.js
@@ -2,6 +2,8 @@ const _ = require('lodash')
 const md = require('./template')
 
 module.exports = ({version, dependencyLink, dependency, oldVersionResolved, type, release, diffCommits}) => md`
+☝️ Greenkeeper’s [updated Terms of Service](https://mailchi.mp/ebfddc9880a9/were-updating-our-terms-of-service) will come into effect on April 6th, 2018.
+
 ## Version **${version}** of ${dependencyLink} was just published.
 
 <table>


### PR DESCRIPTION
Since there are a lot of users who we can’t contact by email, we show a note at the top of every PR or issue for the next six weeks that our Terms of Service have changed.  

Looks like this (but with April 6th instead of 5th) 

![bildschirmfoto 2018-02-21 um 14 16 19](https://user-images.githubusercontent.com/391124/36544588-21c7c220-17e7-11e8-85c5-b6877ebff79c.png)
