### PR TITLE
Test: set content-type header in mock response

### DIFF
--- a/test/lib/get-diff-commits.js
+++ b/test/lib/get-diff-commits.js
@@ -35,7 +35,9 @@ test('get-diff-commits', async t => {
       t.ok(_.includes(text, `abccommitmessage`), 'includes commit message')
       return true
     })
-    .reply(200, 'body <a href="https://github.com/greenkeeperio/greenkeeper">')
+    .reply(200, 'body <a href="https://github.com/greenkeeperio/greenkeeper">', {
+      'content-type': 'text/html;charset=utf-8'
+    })
 
   const diff = await getDiffCommits({
     installationId: '123',


### PR DESCRIPTION
The correct Content-Type header (as returned by GitHub’s API) is required as per https://github.com/octokit/rest.js/commit/02a40deac8a9de8eac61968175853144c091a513 (v15.1.0+)