### PR TITLE
feat: move tos update message to the bottom of issues and PRs

### DIFF
--- a/content/fail-issue.js
+++ b/content/fail-issue.js
@@ -18,8 +18,6 @@ ${statuses.map(status => `- ${status.state === 'success' ? '✅' : '❌'} **${st
 `
 
 module.exports = ({version, dependencyLink, owner, repo, head, dependency, oldVersionResolved, dependencyType, statuses, release, diffCommits}) => md`
-☝️ Greenkeeper’s [updated Terms of Service](https://mailchi.mp/ebfddc9880a9/were-updating-our-terms-of-service) will come into effect on April 6th, 2018.
-
 ## Version **${version}** of ${dependencyLink} was just published.
 
 <table>
@@ -78,6 +76,7 @@ ${_.compact([release, diffCommits])}
 There is a collection of [frequently asked questions](https://greenkeeper.io/faq.html). If those don’t help, you can always [ask the humans behind Greenkeeper](https://github.com/greenkeeperio/greenkeeper/issues/new).
 </details>
 
+☝️ Note: Greenkeeper’s [updated Terms of Service](https://mailchi.mp/ebfddc9880a9/were-updating-our-terms-of-service) will come into effect on April 6th, 2018.
 
 ---
 

--- a/content/initial-pr.js
+++ b/content/initial-pr.js
@@ -138,8 +138,6 @@ const mainMessage = ({enabled, depsUpdated}) => {
 
 function prBody ({ghRepo, success, secret, installationId, newBranch, badgeUrl, travisModified, enabled, depsUpdated, accountTokenUrl, files}) {
   return md`
-☝️ Greenkeeper’s [updated Terms of Service](https://mailchi.mp/ebfddc9880a9/were-updating-our-terms-of-service) will come into effect on April 6th, 2018.
-
 Let’s get started with automated dependency management for ${ghRepo.name} :muscle:
 
 ${hasLockFileText(files)}
@@ -166,6 +164,7 @@ ${
 
 ---
 
+☝️ Note: Greenkeeper’s [updated Terms of Service](https://mailchi.mp/ebfddc9880a9/were-updating-our-terms-of-service) will come into effect on April 6th, 2018.
 
 Good luck with your project and see you soon :sparkles:
 

--- a/content/update-pr.js
+++ b/content/update-pr.js
@@ -2,8 +2,6 @@ const _ = require('lodash')
 const md = require('./template')
 
 module.exports = ({version, dependencyLink, dependency, oldVersionResolved, type, release, diffCommits}) => md`
-☝️ Greenkeeper’s [updated Terms of Service](https://mailchi.mp/ebfddc9880a9/were-updating-our-terms-of-service) will come into effect on April 6th, 2018.
-
 ## Version **${version}** of ${dependencyLink} was just published.
 
 <table>
@@ -53,6 +51,7 @@ ${_.compact([release, diffCommits])}
   There is a collection of [frequently asked questions](https://greenkeeper.io/faq.html). If those don’t help, you can always [ask the humans behind Greenkeeper](https://github.com/greenkeeperio/greenkeeper/issues/new).
 </details>
 
+☝️ Note: Greenkeeper’s [updated Terms of Service](https://mailchi.mp/ebfddc9880a9/were-updating-our-terms-of-service) will come into effect on April 6th, 2018.
 
 ---
 


### PR DESCRIPTION
The terms of service update notification has been at the top of all PRs and issues for a month now, for the remaining two weeks we’ll move it to the bottom so it‘s a bit less invasive.