### PR TITLE
WIP: feat(create-initial-branch): autodiscover package files and generate …

### DIFF
--- a/content/initial-pr.js
+++ b/content/initial-pr.js
@@ -136,7 +136,31 @@ const mainMessage = ({enabled, depsUpdated}) => {
   return '' // no updates, but private repository
 }
 
-function prBody ({ghRepo, success, secret, installationId, newBranch, badgeUrl, travisModified, enabled, depsUpdated, accountTokenUrl, files}) {
+const greenkeeperConfigInfoMessage = (info) => {
+  if (!info) return ''
+  let message = ''
+  if (info.isMonorepo) {
+    message += '📦 📦  Greenkeeper has detected multiple `package.json` files. '
+  }
+  if (info.action === 'new') {
+    message += 'They have all been added to a new `greenkeeper.json` config file. They’ve been collected in a group called `default`, meaning that all of them will receive updates together. You can rename, add and remove groups and freely assign each `package.json` to whichever group you like. It’s common, for example, to have one `frontend` group and one `backend` group, each with a couple of `package.json` files. In any case, all files in a group will have their updates collected into single PRs and issues. '
+  }
+  if (info.action === 'updated') {
+    message += 'Since this repo already has a `greenkeeper.json` config file with defined groups, Greenkeeper has only checked whether they’re still valid. '
+    if (info.deletedPackageFiles.length > 0) {
+      message += 'The follwing `package.json` files could no longer be found in the repo and have been removed from your groups config: `' + info.deletedPackageFiles.join(', ') + '`. '
+    }
+    if (info.deletedGroups.length > 0) {
+      message += 'Also, groups which no longer have any entries have been removed: `' + info.deletedGroups.join(', ') + '`. '
+    }
+  }
+  if (info.action === 'added-groups-only') {
+    message += 'Since this repo already has a `greenkeeper.json` config file without any defined groups, Greenkeeper has  added all of the `package.json` files to a group called `default`, meaning that all of them will receive updates together. You can rename, add and remove groups and freely assign each `package.json` to whichever group you like. It’s common, for example, to have one `frontend` group and one `backend` group, each with a couple of `package.json` files. In any case, all files in a group will have their updates collected into single PRs and issues. '
+  }
+  return message
+}
+
+function prBody ({ghRepo, success, secret, installationId, newBranch, badgeUrl, travisModified, enabled, depsUpdated, accountTokenUrl, files, greenkeeperConfigInfo}) {
   return md`
 ☝️ Greenkeeper’s [updated Terms of Service](https://mailchi.mp/ebfddc9880a9/were-updating-our-terms-of-service) will come into effect on April 6th, 2018.
 
@@ -149,6 +173,8 @@ ${mainMessage({enabled, depsUpdated})}
 ${!enabled && '**Important: Greenkeeper will only start watching this repository’s dependency updates after you merge this initial pull request**.'}
 
 ${secret && accountTokenUrl && `💸  **Warning** 💸 Enabling Greenkeeper on this repository by merging this pull request might increase your monthly payment. If you’re unsure, please [check your billing status](${accountTokenUrl}).`}
+
+${greenkeeperConfigInfoMessage(greenkeeperConfigInfo)}
 
 ---
 ${

--- a/jobs/create-initial-pr.js
+++ b/jobs/create-initial-pr.js
@@ -33,7 +33,8 @@ module.exports = async function (
     travisModified,
     depsUpdated,
     badgeAdded,
-    badgeUrl
+    badgeUrl,
+    greenkeeperConfigInfo
   } = branchDoc
 
   let enabled = false
@@ -123,7 +124,8 @@ module.exports = async function (
         success: combined.state === 'success',
         enabled,
         accountTokenUrl,
-        files
+        files,
+        greenkeeperConfigInfo
       }),
       base,
       head

--- a/lib/get-files.js
+++ b/lib/get-files.js
@@ -16,6 +16,36 @@ async function getGithubFile (ghqueue, { path, owner, repo }) {
   }
 }
 
+// Returns an array of objects, where each object describes a `package.json`:
+// [{"content": "eyJuYW1lIjoidGVzdCJ9", "name": "package.json", "path": "frontend/package.json", "type": "file"}]
+async function discoverPackageFiles (installationId, fullName) {
+  const ghqueue = githubQueue(installationId)
+  const relevantPackageFilePaths = await discoverPackageFilePaths(installationId, fullName)
+  const [owner, repo] = fullName.split('/')
+  // Fetch the content for each relevant package.json file
+  const packageFiles = await Promise.all(
+    relevantPackageFilePaths.map((path) => getGithubFile(ghqueue, { path, owner, repo }))
+  )
+  return packageFiles
+}
+
+// Returns an array of paths of `package.json` files:
+// [ 'package.json', 'frontend/package.json', 'backend/package.json' ]
+async function discoverPackageFilePaths (installationId, fullName) {
+  const query = `filename:package.json+repo:${fullName}`
+  const ghqueue = githubQueue(installationId)
+  const packageFilePaths = (await ghqueue.read(github => github.search.code({q: query, per_page: 100})))
+  // Construct an array of all relevant package.json paths
+  const relevantPackageFilePaths = packageFilePaths.items.map((item) => {
+    // Just pick out the paths, eg. `packages/retext-dutch/package.json`
+    return item.path
+  }).filter((item) => {
+    // We don’t want any package.json files from `node_modules`
+    return !item.includes('node_modules')
+  })
+  return relevantPackageFilePaths
+}
+
 function addRelatedLockfilePaths (files) {
   if (_.isEmpty(files)) return fileList
   if (_.isEmpty(_.difference(files, fileList))) return []
@@ -119,6 +149,8 @@ function formatPackageJson (content) {
 module.exports = {
   getFiles,
   formatPackageJson,
+  discoverPackageFiles,
+  discoverPackageFilePaths,
   getGreenkeeperConfigFile,
   getPackagePathsFromConfigFile
 }

--- a/lib/repository-docs.js
+++ b/lib/repository-docs.js
@@ -66,7 +66,6 @@ async function updateRepoDoc (installationId, doc) {
   return doc
 }
 
-// need to add a top level config key with the contents of the greenkeeperrc
 function createDocs ({ repositories, accountId }) {
   return repositories.map(repo => updatedAt({
     _id: String(repo.id),

--- a/test/jobs/create-initial-branch.js
+++ b/test/jobs/create-initial-branch.js
@@ -339,6 +339,16 @@ describe('create initial branch', () => {
       })
       .get('/rate_limit')
       .reply(200, {})
+      // first time from repository-docs.js -> updateRepoDoc
+      .get('/repos/finnp/test/contents/greenkeeper.json')
+      .reply(404, {
+        message: 'Not Found'
+      })
+      // second time from create-initial-branch.js, before we do the transform
+      .get('/repos/finnp/test/contents/greenkeeper.json')
+      .reply(404, {
+        message: 'Not Found'
+      })
       .get('/search/code?q=filename%3Apackage.json+repo%3Afinnp%2Ftest&per_page=100')
       .reply(200, {
         items: [{path: 'package.json'}, {path: 'frontend/package.json'}]
@@ -433,12 +443,196 @@ describe('create initial branch', () => {
     expect(newBranch.badgeUrl).toEqual('https://badges.greenkeeper.io/finnp/test.svg')
   })
 
+  test('create pull request for monorepo and update existing greenkeeper.json', async () => {
+    const configFileContent = {
+      ignore: [
+        'eslint'
+      ],
+      groups: {
+        build: {
+          packages: [
+            'package.json'
+          ]
+        },
+        frontend: {
+          packages: [
+            'frontend/package.json',
+            'this-file-no-longer-exists/package.json'
+          ]
+        },
+        backend: {
+          packages: [
+            'backend/package.json'
+          ]
+        },
+        empty: {
+          packages: [
+            'this-whole-group-should-disappear/package.json'
+          ]
+        }
+      }
+    }
+    const { repositories } = await dbs()
+    await repositories.put({
+      _id: '48',
+      accountId: '123',
+      fullName: 'finnp/test',
+      greenkeeper: configFileContent
+    })
+    const devDependencies = {
+      '@finnpauls/dep': '1.0.0',
+      '@finnpauls/dep2': '1.0.0'
+    }
+
+    expect.assertions(12)
+
+    nock('https://api.github.com')
+      .post('/installations/37/access_tokens')
+      .reply(200, {
+        token: 'secret'
+      })
+      .get('/rate_limit')
+      .reply(200, {})
+      // first time from repository-docs.js -> updateRepoDoc
+      .get('/repos/finnp/test/contents/greenkeeper.json')
+      .reply(200, {
+        type: 'file',
+        path: 'greenkeeper.json',
+        name: 'greenkeeper.json',
+        content: Buffer.from(JSON.stringify(configFileContent)).toString('base64')
+      })
+      // second time from create-initial-branch.js, before we do the transform
+      .get('/repos/finnp/test/contents/greenkeeper.json')
+      .reply(200, {
+        type: 'file',
+        path: 'greenkeeper.json',
+        name: 'greenkeeper.json',
+        content: Buffer.from(JSON.stringify(configFileContent)).toString('base64')
+      })
+      .get('/search/code?q=filename%3Apackage.json+repo%3Afinnp%2Ftest&per_page=100')
+      .reply(200, {
+        items: [{path: 'package.json'}, {path: 'frontend/package.json'}, {path: 'backend/package.json'}]
+      })
+      .get('/repos/finnp/test/contents/package.json')
+      .reply(200, {
+        path: 'package.json',
+        name: 'package.json',
+        content: encodePkg({ devDependencies })
+      })
+      .get('/repos/finnp/test/contents/frontend/package.json')
+      .reply(200, {
+        path: 'frontend/package.json',
+        name: 'package.json',
+        content: encodePkg({ devDependencies })
+      })
+      .get('/repos/finnp/test/contents/backend/package.json')
+      .reply(200, {
+        path: 'backend/package.json',
+        name: 'package.json',
+        content: encodePkg({ devDependencies })
+      })
+      .get('/repos/finnp/test')
+      .reply(200, {
+        default_branch: 'custom'
+      })
+      .post('/repos/finnp/test/labels', {
+        name: 'greenkeeper',
+        color: '00c775'
+      })
+      .reply(201)
+
+    nock('https://registry.npmjs.org')
+      .get('/@finnpauls%2Fdep')
+      .reply(200, {
+        'dist-tags': {
+          latest: '2.0.0'
+        }
+      })
+      .get('/@finnpauls%2Fdep2')
+      .reply(200, {
+        'dist-tags': {
+          latest: '3.0.0-rc1'
+        },
+        versions: {
+          '2.0.0-rc1': true,
+          '2.0.0-rc2': true,
+          '2.0.0': true,
+          '3.0.0-rc1': true,
+          '1.0.0': true
+        }
+      })
+
+    // mock relative dependencies
+    jest.mock('../../lib/create-branch', () => ({ transforms }) => {
+      //  The module factory of `jest.mock()` is not allowed to reference any out-of-scope variables.
+      const devDependencies = {
+        '@finnpauls/dep': '1.0.0',
+        '@finnpauls/dep2': '1.0.0'
+      }
+
+      const newPkg = JSON.parse(
+        transforms[1].transform(JSON.stringify({ devDependencies }))
+      )
+      transforms[1].created = true
+      expect(newPkg.devDependencies['@finnpauls/dep']).toEqual('2.0.0')
+      expect(newPkg.devDependencies['@finnpauls/dep2']).toEqual('2.0.0')
+
+      const newReadme = transforms[3].transform(
+        'readme-badger\n=============\n',
+        'README.md'
+      )
+      // 'includes badge'
+      expect(newReadme).toMatch(/https:\/\/badges.greenkeeper.io\/finnp\/test.svg/)
+
+      expect(transforms[0].path).toBe('greenkeeper.json')
+      // The `empty` group should disappear completely, since it no longer contains any files
+      // The `frontend` group should not contain `this-file-no-longer-exists/package.json`, since that file
+      // is no longer in the repo
+      expect(JSON.parse(transforms[0].transform())).toEqual({
+        ignore: [
+          'eslint'
+        ],
+        groups: {
+          build: {
+            packages: [
+              'package.json'
+            ]
+          },
+          frontend: {
+            packages: [
+              'frontend/package.json'
+            ]
+          },
+          backend: {
+            packages: [
+              'backend/package.json'
+            ]
+          }
+        }
+      })
+
+      return '1234abcd'
+    })
+    const createInitialBranch = require('../../jobs/create-initial-branch')
+
+    const newJob = await createInitialBranch({repositoryId: 48})
+    const newBranch = await repositories.get('48:branch:1234abcd')
+
+    expect(newJob).toBeTruthy()
+    expect(newJob.data.name).toEqual('initial-timeout-pr')
+    expect(newJob.data.repositoryId).toBe(48)
+    expect(newJob.delay).toBeGreaterThan(10000)
+    expect(newBranch.type).toEqual('branch')
+    expect(newBranch.initial).toBeTruthy()
+    expect(newBranch.badgeUrl).toEqual('https://badges.greenkeeper.io/finnp/test.svg')
+  })
+
   afterAll(async () => {
     const { installations, repositories, payments } = await dbs()
     await Promise.all([
       removeIfExists(installations, '123'),
       removeIfExists(payments, '123'),
-      removeIfExists(repositories, '42', '43', '44', '45', '46', '47', '42:branch:1234abcd', '47:branch:1234abcd')
+      removeIfExists(repositories, '42', '43', '44', '45', '46', '47', '48', '42:branch:1234abcd', '47:branch:1234abcd', '48:branch:1234abcd')
     ])
   })
 

--- a/test/jobs/create-initial-branch.js
+++ b/test/jobs/create-initial-branch.js
@@ -20,7 +20,7 @@ describe('create initial branch', () => {
 
     await installations.put({
       _id: '123',
-      installation: 37,
+      installation: 137,
       plan: 'free'
     })
 
@@ -45,7 +45,7 @@ describe('create initial branch', () => {
     expect.assertions(10)
 
     nock('https://api.github.com')
-      .post('/installations/37/access_tokens')
+      .post('/installations/137/access_tokens')
       .reply(200, {
         token: 'secret'
       })
@@ -147,7 +147,7 @@ describe('create initial branch', () => {
     const createInitialBranch = require('../../jobs/create-initial-branch')
 
     nock('https://api.github.com')
-      .post('/installations/37/access_tokens')
+      .post('/installations/137/access_tokens')
       .reply(200, {
         token: 'secret'
       })
@@ -201,7 +201,7 @@ describe('create initial branch', () => {
     const createInitialBranch = require('../../jobs/create-initial-branch')
 
     nock('https://api.github.com')
-      .post('/installations/37/access_tokens')
+      .post('/installations/137/access_tokens')
       .reply(200, {
         token: 'secret'
       })
@@ -255,7 +255,7 @@ describe('create initial branch', () => {
     const createInitialBranch = require('../../jobs/create-initial-branch')
 
     nock('https://api.github.com')
-      .post('/installations/37/access_tokens')
+      .post('/installations/137/access_tokens')
       .reply(200, {
         token: 'secret'
       })
@@ -300,7 +300,7 @@ describe('create initial branch', () => {
     const createInitialBranch = require('../../jobs/create-initial-branch')
 
     nock('https://api.github.com')
-      .post('/installations/37/access_tokens')
+      .post('/installations/137/access_tokens')
       .reply(200, {
         token: 'secret'
       })
@@ -333,7 +333,7 @@ describe('create initial branch', () => {
     expect.assertions(12)
 
     nock('https://api.github.com')
-      .post('/installations/37/access_tokens')
+      .post('/installations/137/access_tokens')
       .reply(200, {
         token: 'secret'
       })
@@ -487,7 +487,7 @@ describe('create initial branch', () => {
     expect.assertions(12)
 
     nock('https://api.github.com')
-      .post('/installations/37/access_tokens')
+      .post('/installations/137/access_tokens')
       .reply(200, {
         token: 'secret'
       })

--- a/test/lib/create-branch.js
+++ b/test/lib/create-branch.js
@@ -296,7 +296,6 @@ describe('create branch', async () => {
       })
       .post('/repos/owner/repo/git/trees')
       .reply(201, (uri, requestBody) => {
-        console.log('gkj')
         expect(JSON.parse(requestBody).tree[0].path).toEqual('greenkeeper.json')
         expect(JSON.parse(requestBody).tree[0].content).toEqual('{"lol":"wat"}')
         return {sha: 'def456'}

--- a/test/lib/create-branch.js
+++ b/test/lib/create-branch.js
@@ -253,4 +253,120 @@ describe('create branch', async () => {
 
     expect(sha).toEqual('789beef2')
   })
+
+  const testFourData = {
+    'package.json': {
+      dependencies: {
+        standard: '1.0.0'
+      }
+    },
+    'backend/package.json': {
+      dependencies: {
+        standard: '1.0.0'
+      }
+    }
+  }
+
+  test('generate new greenkeeper.json and change multiple monorepo files (package.json, backend/package.json)', async () => {
+    expect.assertions(17)
+
+    ghToken(nock('https://api.github.com'))
+      .get('/repos/owner/repo/contents/greenkeeper.json')
+      .query({ ref: 'master' })
+      .reply(404, {
+        message: 'Not Found'
+      })
+      .get('/repos/owner/repo/contents/package.json')
+      .query({ ref: 'master' })
+      .reply(200, {
+        type: 'file',
+        content: Buffer.from(JSON.stringify(testFourData['package.json'])).toString('base64')
+      })
+      .get('/repos/owner/repo/contents/backend/package.json')
+      .query({ ref: 'master' })
+      .reply(200, {
+        type: 'file',
+        content: Buffer.from(JSON.stringify(testFourData['backend/package.json'])).toString('base64')
+      })
+      .get('/repos/owner/repo/git/refs/heads/master')
+      .reply(200, {
+        object: {
+          sha: '123abc2'
+        }
+      })
+      .post('/repos/owner/repo/git/trees')
+      .reply(201, (uri, requestBody) => {
+        console.log('gkj')
+        expect(JSON.parse(requestBody).tree[0].path).toEqual('greenkeeper.json')
+        expect(JSON.parse(requestBody).tree[0].content).toEqual('{"lol":"wat"}')
+        return {sha: 'def456'}
+      })
+      .post('/repos/owner/repo/git/trees')
+      .reply(201, (uri, requestBody) => {
+        expect(JSON.parse(requestBody).tree[0].path).toEqual('package.json')
+        expect(JSON.parse(requestBody).tree[0].content).toEqual('{"dependencies":{"standard":"2.0.0"}}')
+        return {sha: 'def457'}
+      })
+      .post('/repos/owner/repo/git/trees')
+      .reply(201, (uri, requestBody) => {
+        expect(JSON.parse(requestBody).tree[0].path).toEqual('backend/package.json')
+        expect(JSON.parse(requestBody).tree[0].content).toEqual('{"dependencies":{"standard":"2.0.0"}}')
+        return {sha: 'def458'}
+      })
+      .post('/repos/owner/repo/git/commits')
+      .reply(201, (uri, requestBody) => {
+        expect(JSON.parse(requestBody).tree).toEqual('def456')
+        expect(JSON.parse(requestBody).parents[0]).toEqual('123abc2')
+        expect(JSON.parse(requestBody).message).toEqual('config')
+        return {sha: '789beef0'}
+      })
+      .post('/repos/owner/repo/git/commits')
+      .reply(201, (uri, requestBody) => {
+        expect(JSON.parse(requestBody).tree).toEqual('def457')
+        expect(JSON.parse(requestBody).parents[0]).toEqual('789beef0')
+        expect(JSON.parse(requestBody).message).toEqual('pkg')
+        return {sha: '789beef1'}
+      })
+      .post('/repos/owner/repo/git/commits')
+      .reply(201, (uri, requestBody) => {
+        expect(JSON.parse(requestBody).tree).toEqual('def458')
+        expect(JSON.parse(requestBody).parents[0]).toEqual('789beef1')
+        expect(JSON.parse(requestBody).message).toEqual('pkg2')
+        return {sha: '789beef2'}
+      })
+      .post('/repos/owner/repo/git/refs')
+      .reply(201, (uri, requestBody) => {
+        expect(JSON.parse(requestBody).sha).toEqual('789beef2')
+      })
+
+    const payload = {
+      installationId: 123,
+      owner: 'owner',
+      repo: 'repo',
+      branch: 'master',
+      newBranch: 'testBranch',
+      transforms: [
+        {
+          path: 'greenkeeper.json',
+          message: 'config',
+          transform: () => '{"lol":"wat"}',
+          create: true
+        },
+        {
+          path: 'package.json',
+          message: 'pkg',
+          transform: (old, path) => createTransformFunction('dependencies', 'standard', '2.0.0', console)(old)
+        },
+        {
+          path: 'backend/package.json',
+          message: 'pkg2',
+          transform: (old, path) => createTransformFunction('dependencies', 'standard', '2.0.0', console)(old)
+        }
+      ]
+    }
+
+    const sha = await createBranch(payload)
+
+    expect(sha).toEqual('789beef2')
+  })
 })


### PR DESCRIPTION
…greenkeeper.json

This hooks into `create-initial-branch.js` and adds a transform which generates a `greenkeeper.json` commit if the repo is a monorepo (i.e. has at least one `package.json` file which is not at the repo root). It doesn’t directly touch the repo doc, only the initial branch. 

### Changes:
- add `discoverPackageFilePaths` to `get-files.js`, returns an array of package files (with any from `node_modules` removed): `[ 'package.json', 'frontend/package.json', 'backend/package.json' ]`, this is useful for generating the `greenkeeper.json`
- add `discoverPackageFiles` to `get-files.js`, this returns the full package file info with content for multiple files in the format expected by `get-files.js -> formatPackageJson()` : `[{"content": "eyJuYW1lIjoidGVzdCJ9", "name": "package.json", "path": "frontend/package.json", "type": "file"}]`
- generates a new `greenkeeper.json` if the repo is a monorepo, with a default group that contains all found package.json files
- updates an existing `greenkeeper.json` by checking each package file path in each group, and removing out of date package file paths and empty groups.