### PR TITLE
Feat/invalid config file issue

### DIFF
--- a/content/invalid-config-issue.js
+++ b/content/invalid-config-issue.js
@@ -1,12 +1,46 @@
 const md = require('./template')
 
-// TODO: write something better!
+module.exports = (messages) => {
+  let messageList = messages.map((message, index) => {
+    return `${index + 1}. ${message}`
+  }).join('\n')
 
-module.exports = ({message, errors}) =>
-md`We have detected a Problem with your Greenkeeper Config File 🚨
+  return md`We have detected a problem with your Greenkeeper config file 🚨
 
-${message}
+Greenkeeper currently can’t work with your \`greenkeeper.json\` config file because it is invalid. We found the following issue${messages.length === 1 ? '' : 's'}:
 
-Example of a valid config object link
+${messageList}
 
-`
+Please correct ${messages.length === 1 ? 'this' : 'these'} and commit the fix to your default branch (usually master). Greenkeeper will pick up your changes and try again. If in doubt, please consult the [config documentation](https://greenkeeper.io/docs).
+
+Here’s an example of a valid \`greenkeeper.json\`:
+
+\`\`\`javascript
+{
+  groups: {
+    frontend: {
+      packages: [
+        'webapp/package.json',
+        'cms/package.json',
+        'analytics/package.json'
+      ]
+    },
+    build: {
+      packages: [
+        'package.json'
+      ]
+    }
+  },
+  ignore: [
+    'standard',
+    'eslint'
+  ]
+}
+\`\`\`
+
+This files tells Greenkeeper to handle all dependency updates in two groups. All files in the \`frontend\` group will receive updates together, in one issue or PR, and the root-level \`package.json\` in the \`build\` group will be treated separately. In addition, Greenkeeper will never send updates for the \`standard\` and \`eslint\` packages.
+
+🤖 🌴
+
+  `
+}

--- a/content/invalid-config-issue.js
+++ b/content/invalid-config-issue.js
@@ -11,7 +11,7 @@ Greenkeeper currently can’t work with your \`greenkeeper.json\` config file be
 
 ${messageList}
 
-Please correct ${messages.length === 1 ? 'this' : 'these'} and commit the fix to your default branch (usually master). Greenkeeper will pick up your changes and try again. If in doubt, please consult the [config documentation](https://greenkeeper.io/docs).
+Please correct ${messages.length === 1 ? 'this' : 'these'} and commit the fix to your default branch (usually master). Greenkeeper will pick up your changes and try again. If in doubt, please consult the [config documentation](https://greenkeeper.io/docs.html#config).
 
 Here’s an example of a valid \`greenkeeper.json\`:
 

--- a/jobs/github-event/push.js
+++ b/jobs/github-event/push.js
@@ -73,7 +73,7 @@ module.exports = async function (data) {
       return {
         data: {
           name: 'invalid-config-file',
-          message: configValidation.error.details[0].message,
+          messages: _.map(configValidation.error.details, 'formattedMessage'),
           errors: configValidation.error.details,
           repositoryId,
           accountId: repoDoc.accountId

--- a/jobs/invalid-config-file.js
+++ b/jobs/invalid-config-file.js
@@ -30,8 +30,8 @@ module.exports = async function ({ repositoryId, accountId, messages }) {
   const { number } = await githubQueue(installationId).write(github => github.issues.create({
     owner,
     repo,
-    title: `Invalid Greenkeeper Configuration file`,
-    body: invalidConfigBody({ messages }),
+    title: `Invalid Greenkeeper configuration file`,
+    body: invalidConfigBody(messages),
     labels: [label]
   }))
 

--- a/jobs/invalid-config-file.js
+++ b/jobs/invalid-config-file.js
@@ -7,7 +7,7 @@ const updatedAt = require('../lib/updated-at')
 const invalidConfigBody = require('../content/invalid-config-issue')
 const getConfig = require('../lib/get-config')
 
-module.exports = async function ({ repositoryId, accountId, message }) {
+module.exports = async function ({ repositoryId, accountId, messages }) {
   const { installations, repositories } = await dbs()
   const installation = await installations.get(String(accountId))
   const installationId = installation.installation
@@ -22,16 +22,6 @@ module.exports = async function ({ repositoryId, accountId, message }) {
   // don't send too many issues!
   if (openIssues && openIssues.length) return
 
-  // TODO: bring errors messages in a format that can be used in the issue body
-  // error example:
-  // { message: '"#invalid#groupname#" is not allowed',
-  //     path: [ 'groups', '#invalid#groupname#' ],
-  //     type: 'object.allowUnknown',
-  //     context:
-  //      { child: '#invalid#groupname#',
-  //        key: '#invalid#groupname#',
-  //        label: '#invalid#groupname#' } }
-
   const repoDoc = await repositories.get(String(repositoryId))
   const { fullName } = repoDoc
   const [owner, repo] = fullName.split('/')
@@ -41,7 +31,7 @@ module.exports = async function ({ repositoryId, accountId, message }) {
     owner,
     repo,
     title: `Invalid Greenkeeper Configuration file`,
-    body: invalidConfigBody({ message }),
+    body: invalidConfigBody({ messages }),
     labels: [label]
   }))
 

--- a/lib/validate-greenkeeper-json.js
+++ b/lib/validate-greenkeeper-json.js
@@ -2,7 +2,7 @@ const Joi = require('joi')
 
 // a package path is either the term 'package.json' or
 // a releative path that ends in package.json
-// alternitive regex: ^([^/]|p).*ackage\.json$
+// alternative regex: ^([^/]|p).*ackage\.json$
 const packagePathSchema = Joi.string().regex(/^(\w+\/[\w/]*)?package\.json$/)
 
 const schema = Joi.object().keys({
@@ -16,7 +16,35 @@ const schema = Joi.object().keys({
 }).optionalKeys(['ignore'])
 
 function validate (file) {
-  return Joi.validate(file, schema)
+  let errors = Joi.validate(file, schema, {
+    abortEarly: false
+  })
+  if (errors.error) {
+    errors.error.details.map((e) => {
+      // Fall back to the standard Joi message if we don’t have a better one
+      e.formattedMessage = e.message
+      if (e.type === 'string.regex.base') {
+        e.formattedMessage = `The package path \`${e.context.value}\` in the group \`${e.path[1]}\` is invalid. It must be a relative path to a \`package.json\` file. The path may not start with a slash or an \`@\`, and it must end in \`package.json\`.`
+      }
+      if (e.type === 'string.regex.base' && e.context.value.startsWith('/')) {
+        e.formattedMessage = `The package path \`${e.context.value}\` in the group \`${e.path[1]}\` must be relative and not start with a slash.`
+      }
+      if (e.type === 'string.regex.base' && !e.context.value.endsWith('package.json')) {
+        e.formattedMessage = `The package path \`${e.context.value}\` in the group \`${e.path[1]}\` must end with \`package.json\`.`
+      }
+      if (e.type === 'object.allowUnknown' && e.path[0] === 'groups') {
+        e.formattedMessage = `The group name \`${e.context.child}\` is invalid. Group names may only contain alphanumeric characters and underscores (a-zA-Z_).`
+      }
+      if (e.type === 'object.allowUnknown' && e.path[0] !== 'groups') {
+        e.formattedMessage = `The root-level key \`${e.context.child}\` is invalid. If you meant to add a group named \`${e.context.child}\`, please put it in a root-level \`groups\` object. Valid root-level keys are \`groups\` and \`ignore\`.`
+      }
+      if (e.message === '"packages" is required') {
+        e.formattedMessage = `The group \`${e.path[1]}\` must contain a \`packages\` key. This must contain an array of paths to the \`package.json\` files you want handled in this group, eg. \`packages: ['cli-tool/package.json', 'analytics/package.json']\`.`
+      }
+    })
+  }
+
+  return errors
 }
 
 module.exports = {

--- a/test/jobs/github-event/push.js
+++ b/test/jobs/github-event/push.js
@@ -3415,7 +3415,7 @@ describe('github-event push: monorepo', () => {
     expect(newJob).toBeTruthy()
     const job = newJob.data
     expect(job.name).toEqual('invalid-config-file')
-    expect(job.message).toEqual('"#invalid#groupname#" is not allowed')
+    expect(job.messages[0]).toEqual('The group name `#invalid#groupname#` is invalid. Group names may only contain alphanumeric characters and underscores (a-zA-Z_).')
 
     const expectedFiles = {
       'package.json': ['package.json'],
@@ -3522,7 +3522,8 @@ describe('github-event push: monorepo', () => {
     expect(newJob).toBeTruthy()
     const job = newJob.data
     expect(job.name).toEqual('invalid-config-file')
-    expect(job.message).toMatch(/"0" with value "@package.json" fails to match the required pattern/)
+    console.log('job', job)
+    expect(job.messages[0]).toEqual('The package path `@package.json` in the group `valid_groupname` is invalid. It must be a relative path to a `package.json` file. The path may not start with a slash or an `@`, and it must end in `package.json`.')
 
     const expectedFiles = {
       'package.json': ['package.json'],
@@ -3629,7 +3630,7 @@ describe('github-event push: monorepo', () => {
     expect(newJob).toBeTruthy()
     const job = newJob.data
     expect(job.name).toEqual('invalid-config-file')
-    expect(job.message).toEqual('"#invalid#groupname#" is not allowed')
+    expect(job.messages[0]).toEqual('The group name `#invalid#groupname#` is invalid. Group names may only contain alphanumeric characters and underscores (a-zA-Z_).')
 
     const expectedFiles = {
       'package.json': ['package.json'],
@@ -3752,7 +3753,7 @@ describe('github-event push: monorepo', () => {
     expect(newJob).toBeTruthy()
     const job = newJob.data
     expect(job.name).toEqual('invalid-config-file')
-    expect(job.message).toEqual('"#invalid#groupname#" is not allowed')
+    expect(job.messages[0]).toEqual('The group name `#invalid#groupname#` is invalid. Group names may only contain alphanumeric characters and underscores (a-zA-Z_).')
 
     const expectedFiles = {
       'package.json': ['package.json'],
@@ -3868,7 +3869,7 @@ describe('github-event push: monorepo', () => {
     expect(newJob).toBeTruthy()
     const job = newJob.data
     expect(job.name).toEqual('invalid-config-file')
-    expect(job.message).toMatch(/"0" with value "@package.json" fails to match the required pattern/)
+    expect(job.messages[0]).toEqual('The package path `@package.json` in the group `valid_groupname` is invalid. It must be a relative path to a `package.json` file. The path may not start with a slash or an `@`, and it must end in `package.json`.')
 
     const expectedFiles = {
       'package.json': ['package.json'],
@@ -3984,7 +3985,7 @@ describe('github-event push: monorepo', () => {
     expect(newJob).toBeTruthy()
     const job = newJob.data
     expect(job.name).toEqual('invalid-config-file')
-    expect(job.message).toEqual('"#invalid#groupname#" is not allowed')
+    expect(job.messages[0]).toEqual('The group name `#invalid#groupname#` is invalid. Group names may only contain alphanumeric characters and underscores (a-zA-Z_).')
 
     const expectedFiles = {
       'package.json': ['package.json'],

--- a/test/lib/validate-greenkeeper-json.js
+++ b/test/lib/validate-greenkeeper-json.js
@@ -75,6 +75,7 @@ test('invalid: groupname has invalid characters', () => {
   const result = validate(file)
   expect(result.error).toBeTruthy()
   expect(result.error.details[0].message).toMatch(/"front-end" is not allowed/)
+  expect(result.error.details[0].formattedMessage).toMatch('The group name `front-end` is invalid. Group names may only contain alphanumeric characters and underscores (a-zA-Z_).')
 })
 
 test('invalid: absolute paths are not allowed', () => {
@@ -93,6 +94,7 @@ test('invalid: absolute paths are not allowed', () => {
   expect(result.error.details[0].path).toEqual([ 'groups', 'frontend', 'packages', 0 ])
   expect(result.error.details[0].context.value).toEqual('/packages/frontend/package.json')
   expect(result.error.details[0].message).toMatch(/fails to match the required pattern/)
+  expect(result.error.details[0].formattedMessage).toMatch('The package path `/packages/frontend/package.json` in the group `frontend` must be relative and not start with a slash.')
 })
 
 test('invalid: path is not ending on `package.json`', () => {
@@ -112,6 +114,7 @@ test('invalid: path is not ending on `package.json`', () => {
   expect(result.error.details[0].path).toEqual([ 'groups', 'frontend', 'packages', 1 ])
   expect(result.error.details[0].context.value).toEqual('packages/frontend/')
   expect(result.error.details[0].message).toMatch(/fails to match the required pattern/)
+  expect(result.error.details[0].formattedMessage).toMatch('The package path `packages/frontend/` in the group `frontend` must end with `package.json`.')
 })
 
 test('invalid: group/s not under group key', () => {
@@ -133,7 +136,9 @@ test('invalid: group/s not under group key', () => {
   expect(result.error.name).toEqual('ValidationError')
   expect(result.error.details.length).toEqual(2)
   expect(result.error.details[0].message).toMatch(/"frontend" is not allowed/)
+  expect(result.error.details[0].formattedMessage).toMatch('The root-level key `frontend` is invalid. If you meant to add a group named `frontend`, please put it in a root-level `groups` object. Valid root-level keys are `groups` and `ignore`.')
   expect(result.error.details[1].message).toMatch(/"backend" is not allowed/)
+  expect(result.error.details[1].formattedMessage).toMatch('The root-level key `backend` is invalid. If you meant to add a group named `backend`, please put it in a root-level `groups` object. Valid root-level keys are `groups` and `ignore`.')
 })
 
 test('invalid: no packages', () => {
@@ -155,4 +160,49 @@ test('invalid: no packages', () => {
   expect(result.error).toBeTruthy()
   expect(result.error.name).toEqual('ValidationError')
   expect(result.error.details[0].message).toMatch(/"packages" is required/)
+  expect(result.error.details[0].formattedMessage).toMatch(/The group `frontend` must contain a `packages` key./)
+})
+
+test('invalid: no packages and invalid root level key', () => {
+  const file = {
+    groups: {
+      frontend: {
+        ignore: [
+          'lodash'
+        ]
+      },
+      backend: {
+        packages: [
+          'packages/backend/package.json'
+        ]
+      }
+    },
+    badgers: {
+      dangerous: true
+    }
+  }
+  const result = validate(file)
+  expect(result.error).toBeTruthy()
+  expect(result.error.name).toEqual('ValidationError')
+  expect(result.error.details[0].message).toMatch(/"packages" is required/)
+  expect(result.error.details[0].formattedMessage).toMatch(/The group `frontend` must contain a `packages` key./)
+  expect(result.error.details[1].message).toMatch(/"badgers" is not allowed/)
+  expect(result.error.details[1].formattedMessage).toMatch('The root-level key `badgers` is invalid. If you meant to add a group named `badgers`, please put it in a root-level `groups` object. Valid root-level keys are `groups` and `ignore`.')
+})
+
+test('invalid: catches invalid chars in otherwise valid package path', () => {
+  const file = {
+    groups: {
+      backend: {
+        packages: [
+          'packages/@&|backend/package.json'
+        ]
+      }
+    }
+  }
+  const result = validate(file)
+  expect(result.error).toBeTruthy()
+  expect(result.error.name).toEqual('ValidationError')
+  expect(result.error.details[0].message).toMatch(/fails to match the required pattern/)
+  expect(result.error.details[0].formattedMessage).toEqual('The package path `packages/@&|backend/package.json` in the group `backend` is invalid. It must be a relative path to a `package.json` file. The path may not start with a slash or an `@`, and it must end in `package.json`.')
 })


### PR DESCRIPTION
### Changes:
- generates additional `formattedMessage` values for Joi’s `error.details` objects. These messages are much nicer, more granular and more actionable than the ones Joi produces.
- Joi returns all validation errors now, not just the first one
- `invalid-config-issue.js` now takes an array of messages as its only argument and produces something like this (wording is slightly different now):

![bildschirmfoto 2018-03-28 um 11 11 50](https://user-images.githubusercontent.com/391124/38020364-519c2b14-327a-11e8-918f-b7514229e942.png)

**Note:** The URL in the issue body currently just points to the docs page, not to a specific anchor on it. 