### PR TITLE
fix(create-inital-branch): save generated greenkeeper config to the repoDoc

### DIFF
--- a/lib/get-files.js
+++ b/lib/get-files.js
@@ -57,8 +57,10 @@ async function discoverPackageFilePaths ({installationId, fullName, defaultBranc
 }
 
 function addRelatedLockfilePaths (files) {
-  if (_.isEmpty(files)) return fileList
-  if (_.isEmpty(_.difference(files, fileList))) return []
+  // return standard file list
+  if (_.isEmpty(files) || files === ['package.json']) return fileList
+  // nothing to add
+  if (_.isEqual(fileList, files)) return []
   let relatedLockfilePaths = []
   files.map(path => {
     relatedLockfilePaths.push(path.replace('package.json', 'package-lock.json'))

--- a/lib/repository-docs.js
+++ b/lib/repository-docs.js
@@ -32,12 +32,6 @@ async function updateRepoDoc ({installationId, doc, filePaths, log}) {
   }
   let filePathsFromConfig = []
 
-  // try to get file paths from either the autodiscovered filePaths
-  // or from the greenkeeper.json
-  if (!_.isEmpty(filePaths)) {
-    log.info('setting file paths to the ones found per autodiscovery')
-    filePathsFromConfig = getPackagePathsFromConfigFile(filePaths)
-  }
   if (!_.isEmpty(greenkeeperConfigFile)) {
     if (validate(greenkeeperConfigFile).error) {
       log.info('setting file paths to the ones from the old greenkeeper.json')
@@ -48,6 +42,12 @@ async function updateRepoDoc ({installationId, doc, filePaths, log}) {
     }
   }
 
+  // try to get file paths from either the autodiscovered filePaths
+  // or from the greenkeeper.json
+  if (!_.isEmpty(filePaths)) {
+    log.info('setting file paths to the ones found per autodiscovery')
+    filePathsFromConfig = getPackagePathsFromConfigFile({groups: {default: {packages: filePaths}}})
+  }
   log.info('requesting files from GitHub', {files: filePathsFromConfig})
   const filesFromConfig = _.isEmpty(filePathsFromConfig)
     ? await getFiles(installationId, fullName)


### PR DESCRIPTION
- it now saves the (complete) config to the repoDoc under the key 'greenkeeper'
- put the updating of an existing greenkeeper.json into a function
  - had to get rid of the greenkeeperConfigInfo but added logs with infos
- updated updateRepoDoc so it always prioritises the filePaths from the auto discovery
