### PR TITLE
WIP: fix checking for lockfiles

### DIFF
--- a/test/jobs/create-version-branch.js
+++ b/test/jobs/create-version-branch.js
@@ -58,6 +58,11 @@ describe('create version brach', () => {
             label: 'customlabel'
           }
         }
+      },
+      files: {
+        'package.json': ['package.json'],
+        'yarn.lock': [],
+        'npm-shrinkwrap.json': []
       }
     })
     expect.assertions(13)
@@ -186,6 +191,11 @@ describe('create version brach', () => {
             label: 'customlabel'
           }
         }
+      },
+      files: {
+        'package.json': ['package.json'],
+        'yarn.lock': [],
+        'npm-shrinkwrap.json': []
       }
     })
     await payments.put({
@@ -316,6 +326,11 @@ describe('create version brach', () => {
             label: 'customlabel'
           }
         }
+      },
+      files: {
+        'package.json': ['package.json'],
+        'yarn.lock': [],
+        'npm-shrinkwrap.json': []
       }
     })
     expect.assertions(13)
@@ -445,6 +460,11 @@ describe('create version brach', () => {
             label: 'customlabel'
           }
         }
+      },
+      files: {
+        'package.json': ['package.json'],
+        'yarn.lock': [],
+        'npm-shrinkwrap.json': []
       }
     })
     await payments.put({
@@ -520,6 +540,11 @@ describe('create version brach', () => {
               label: 'customlabel'
             }
           }
+        },
+        files: {
+          'package.json': ['package.json'],
+          'yarn.lock': [],
+          'npm-shrinkwrap.json': []
         }
       })
     ])
@@ -624,6 +649,11 @@ describe('create version brach', () => {
             label: 'customlabel'
           }
         }
+      },
+      files: {
+        'package.json': ['package.json'],
+        'yarn.lock': [],
+        'npm-shrinkwrap.json': []
       }
     })
     expect.assertions(2)
@@ -704,6 +734,11 @@ describe('create version brach', () => {
             ignore: ['a', 'b', 'c']
           }
         }
+      },
+      files: {
+        'package.json': ['package.json'],
+        'yarn.lock': [],
+        'npm-shrinkwrap.json': []
       }
     })
 
@@ -733,10 +768,10 @@ describe('create version brach', () => {
       accountId: '2323',
       fullName: 'espy/test',
       files: {
-        'package.json': true,
-        'package-lock.json': false,
-        'npm-shrinkwrap.json': true,
-        'yarn.lock': false
+        'package.json': ['package.json'],
+        'package-lock.json': [],
+        'npm-shrinkwrap.json': ['npm-shrinkwrap.json'],
+        'yarn.lock': []
       },
       packages: {
         'package.json': {}
@@ -769,10 +804,10 @@ describe('create version brach', () => {
       accountId: '2323',
       fullName: 'espy/test',
       files: {
-        'package.json': true,
-        'package-lock.json': true,
-        'npm-shrinkwrap.json': false,
-        'yarn.lock': false
+        'package.json': ['package.json'],
+        'package-lock.json': ['package-lock.json'],
+        'npm-shrinkwrap.json': [],
+        'yarn.lock': []
       },
       packages: {
         'package.json': {}
@@ -805,10 +840,10 @@ describe('create version brach', () => {
       accountId: '2323',
       fullName: 'espy/test',
       files: {
-        'package.json': true,
-        'package-lock.json': true,
-        'npm-shrinkwrap.json': false,
-        'yarn.lock': false
+        'package.json': 'package.json',
+        'package-lock.json': ['package-lock.json'],
+        'npm-shrinkwrap.json': [],
+        'yarn.lock': []
       },
       packages: {
         'package.json': {
@@ -848,10 +883,10 @@ describe('create version brach', () => {
       accountId: '2323',
       fullName: 'espy/test',
       files: {
-        'package.json': true,
-        'package-lock.json': true,
-        'npm-shrinkwrap.json': false,
-        'yarn.lock': false
+        'package.json': ['package.json'],
+        'package-lock.json': ['package-lock.json'],
+        'npm-shrinkwrap.json': [],
+        'yarn.lock': []
       },
       packages: {
         'package.json': {


### PR DESCRIPTION
if I have checked correctly then `_.some(_.pick(repository.files, projectLockFiles))` does not behave how we want it now that we changes the value of each files-file from true to array (empty or with paths) --> `hasProjectLockFile` & `hasModuleLockFile` need to check with a different function

we often just check if `newJob = falsy` but we should check if branches get created for in-range dependency updates too! Often they don't result in a PR  most of the time they just get deleted again and that also doesn't return a new job!  --> we need better/more tests here. 
Currently the tests pass (to my surprise) and I'm nearly sure that they should not... that's why I think we need to test if in some cases a branch is created instead
