### PR TITLE
fix: validate package paths and groupnames more leniently

### DIFF
--- a/lib/validate-greenkeeper-json.js
+++ b/lib/validate-greenkeeper-json.js
@@ -3,10 +3,10 @@ const Joi = require('joi')
 // a package path is either the term 'package.json' or
 // a releative path that ends in package.json
 // alternative regex: ^([^/]|p).*ackage\.json$
-const packagePathSchema = Joi.string().regex(/^(\w+\/[\w/]*)?package\.json$/)
+const packagePathSchema = Joi.string().regex(/^([a-zA-Z0-9_@-]+\/[a-zA-Z0-9_@/-]*)?package\.json$/)
 
 const schema = Joi.object().keys({
-  groups: Joi.object().pattern(/^[a-zA-Z0-9_]+$/,
+  groups: Joi.object().pattern(/^[a-zA-Z0-9_-]+$/,
     Joi.object().keys({
       packages: Joi.array().items(packagePathSchema).required(),
       ignore: Joi.array()
@@ -15,6 +15,7 @@ const schema = Joi.object().keys({
   ignore: Joi.array()
 }).optionalKeys(['ignore'])
 
+// Abort early still doesn’t handle multiple _nested_ errors (in the same branch of the JSON tree).
 function validate (file) {
   let errors = Joi.validate(file, schema, {
     abortEarly: false
@@ -24,7 +25,7 @@ function validate (file) {
       // Fall back to the standard Joi message if we don’t have a better one
       e.formattedMessage = e.message
       if (e.type === 'string.regex.base') {
-        e.formattedMessage = `The package path \`${e.context.value}\` in the group \`${e.path[1]}\` is invalid. It must be a relative path to a \`package.json\` file. The path may not start with a slash or an \`@\`, and it must end in \`package.json\`.`
+        e.formattedMessage = `The package path \`${e.context.value}\` in the group \`${e.path[1]}\` is invalid. It must be a relative path to a \`package.json\` file. The path may not start with a slash, and it must end in \`package.json\`.`
       }
       if (e.type === 'string.regex.base' && e.context.value.startsWith('/')) {
         e.formattedMessage = `The package path \`${e.context.value}\` in the group \`${e.path[1]}\` must be relative and not start with a slash.`
@@ -33,7 +34,7 @@ function validate (file) {
         e.formattedMessage = `The package path \`${e.context.value}\` in the group \`${e.path[1]}\` must end with \`package.json\`.`
       }
       if (e.type === 'object.allowUnknown' && e.path[0] === 'groups') {
-        e.formattedMessage = `The group name \`${e.context.child}\` is invalid. Group names may only contain alphanumeric characters and underscores (a-zA-Z_).`
+        e.formattedMessage = `The group name \`${e.context.child}\` is invalid. Group names may only contain alphanumeric characters, underscores, dashes and the @ symbol (a-zA-Z_@-).`
       }
       if (e.type === 'object.allowUnknown' && e.path[0] !== 'groups') {
         e.formattedMessage = `The root-level key \`${e.context.child}\` is invalid. If you meant to add a group named \`${e.context.child}\`, please put it in a root-level \`groups\` object. Valid root-level keys are \`groups\` and \`ignore\`.`

--- a/lib/validate-greenkeeper-json.js
+++ b/lib/validate-greenkeeper-json.js
@@ -15,8 +15,8 @@ const schema = Joi.object().keys({
   ignore: Joi.array()
 }).optionalKeys(['ignore'])
 
-// Abort early still doesn’t handle multiple _nested_ errors (in the same branch of the JSON tree).
 function validate (file) {
+  // Abort early still doesn’t handle multiple _nested_ errors (in the same branch of the JSON tree).
   let errors = Joi.validate(file, schema, {
     abortEarly: false
   })
@@ -25,7 +25,7 @@ function validate (file) {
       // Fall back to the standard Joi message if we don’t have a better one
       e.formattedMessage = e.message
       if (e.type === 'string.regex.base') {
-        e.formattedMessage = `The package path \`${e.context.value}\` in the group \`${e.path[1]}\` is invalid. It must be a relative path to a \`package.json\` file. The path may not start with a slash, and it must end in \`package.json\`.`
+        e.formattedMessage = `The package path \`${e.context.value}\` in the group \`${e.path[1]}\` is invalid. It must be a relative path to a \`package.json\` file. The path may not start with a slash, and it must end in \`package.json\`. Allowed characters for a path are alphanumeric, underscores, dashes and the @ symbol (a-zA-Z_-@).`
       }
       if (e.type === 'string.regex.base' && e.context.value.startsWith('/')) {
         e.formattedMessage = `The package path \`${e.context.value}\` in the group \`${e.path[1]}\` must be relative and not start with a slash.`
@@ -34,7 +34,7 @@ function validate (file) {
         e.formattedMessage = `The package path \`${e.context.value}\` in the group \`${e.path[1]}\` must end with \`package.json\`.`
       }
       if (e.type === 'object.allowUnknown' && e.path[0] === 'groups') {
-        e.formattedMessage = `The group name \`${e.context.child}\` is invalid. Group names may only contain alphanumeric characters, underscores, dashes and the @ symbol (a-zA-Z_@-).`
+        e.formattedMessage = `The group name \`${e.context.child}\` is invalid. Group names may only contain alphanumeric characters, underscores and dashes (a-zA-Z_-).`
       }
       if (e.type === 'object.allowUnknown' && e.path[0] !== 'groups') {
         e.formattedMessage = `The root-level key \`${e.context.child}\` is invalid. If you meant to add a group named \`${e.context.child}\`, please put it in a root-level \`groups\` object. Valid root-level keys are \`groups\` and \`ignore\`.`

--- a/test/jobs/create-version-branch.js
+++ b/test/jobs/create-version-branch.js
@@ -7,6 +7,8 @@ const { cleanCache } = require('../helpers/module-cache-helpers')
 nock.disableNetConnect()
 nock.enableNetConnect('localhost')
 
+jest.setTimeout(10000)
+
 describe('create version brach', () => {
   beforeEach(() => {
     delete process.env.IS_ENTERPRISE

--- a/test/jobs/create-version-branch.js
+++ b/test/jobs/create-version-branch.js
@@ -15,6 +15,7 @@ describe('create version brach', () => {
     cleanCache('../../lib/env')
     jest.resetModules()
     jest.clearAllMocks()
+    nock.cleanAll()
   })
   beforeAll(async () => {
     const { installations } = await dbs()

--- a/test/jobs/github-event/push.js
+++ b/test/jobs/github-event/push.js
@@ -3332,7 +3332,7 @@ describe('github-event push: monorepo', () => {
       - [x] invalid package-path
       - [x] invalid groupname and package-path
   */
-  test('monorepo: invalid groupname greenkeeper.json added by user (mga1)', async () => {
+  test('monorepo: invalid groupname added to greenkeeper.json by user (mga1)', async () => {
     const configFileContent = {
       groups: {
         '#invalid#groupname#': {
@@ -3415,7 +3415,7 @@ describe('github-event push: monorepo', () => {
     expect(newJob).toBeTruthy()
     const job = newJob.data
     expect(job.name).toEqual('invalid-config-file')
-    expect(job.messages[0]).toEqual('The group name `#invalid#groupname#` is invalid. Group names may only contain alphanumeric characters and underscores (a-zA-Z_).')
+    expect(job.messages[0]).toEqual('The group name `#invalid#groupname#` is invalid. Group names may only contain alphanumeric characters, underscores, dashes and the @ symbol (a-zA-Z_@-).')
 
     const expectedFiles = {
       'package.json': ['package.json'],
@@ -3444,7 +3444,7 @@ describe('github-event push: monorepo', () => {
       groups: {
         'valid_groupname': {
           packages: [
-            '@package.json'
+            '/package.json'
           ]
         }
       }
@@ -3522,7 +3522,7 @@ describe('github-event push: monorepo', () => {
     expect(newJob).toBeTruthy()
     const job = newJob.data
     expect(job.name).toEqual('invalid-config-file')
-    expect(job.messages[0]).toEqual('The package path `@package.json` in the group `valid_groupname` is invalid. It must be a relative path to a `package.json` file. The path may not start with a slash or an `@`, and it must end in `package.json`.')
+    expect(job.messages[0]).toEqual('The package path `/package.json` in the group `valid_groupname` must be relative and not start with a slash.')
 
     const expectedFiles = {
       'package.json': ['package.json'],
@@ -3546,12 +3546,15 @@ describe('github-event push: monorepo', () => {
     expect(repo.headSha).toEqual('9049f1265b7d61be4a8904a9a27120d2064dab3b')
   })
 
+  /*
+    Joi only returns one message here, because the errors are nested
+  */
   test('monorepo: invalid groupName & package-path greenkeeper.json added by user (mga3)', async () => {
     const configFileContent = {
       groups: {
         '#invalid#groupname#': {
           packages: [
-            '@package.json'
+            '/package.json'
           ]
         }
       }
@@ -3629,7 +3632,7 @@ describe('github-event push: monorepo', () => {
     expect(newJob).toBeTruthy()
     const job = newJob.data
     expect(job.name).toEqual('invalid-config-file')
-    expect(job.messages[0]).toEqual('The group name `#invalid#groupname#` is invalid. Group names may only contain alphanumeric characters and underscores (a-zA-Z_).')
+    expect(job.messages[0]).toEqual('The group name `#invalid#groupname#` is invalid. Group names may only contain alphanumeric characters, underscores, dashes and the @ symbol (a-zA-Z_@-).')
 
     const expectedFiles = {
       'package.json': ['package.json'],
@@ -3752,7 +3755,7 @@ describe('github-event push: monorepo', () => {
     expect(newJob).toBeTruthy()
     const job = newJob.data
     expect(job.name).toEqual('invalid-config-file')
-    expect(job.messages[0]).toEqual('The group name `#invalid#groupname#` is invalid. Group names may only contain alphanumeric characters and underscores (a-zA-Z_).')
+    expect(job.messages[0]).toEqual('The group name `#invalid#groupname#` is invalid. Group names may only contain alphanumeric characters, underscores, dashes and the @ symbol (a-zA-Z_@-).')
 
     const expectedFiles = {
       'package.json': ['package.json'],
@@ -3833,7 +3836,7 @@ describe('github-event push: monorepo', () => {
           groups: {
             'valid_groupname': {
               packages: [
-                '@package.json'
+                '/package.json'
               ]
             }
           }
@@ -3868,7 +3871,7 @@ describe('github-event push: monorepo', () => {
     expect(newJob).toBeTruthy()
     const job = newJob.data
     expect(job.name).toEqual('invalid-config-file')
-    expect(job.messages[0]).toEqual('The package path `@package.json` in the group `valid_groupname` is invalid. It must be a relative path to a `package.json` file. The path may not start with a slash or an `@`, and it must end in `package.json`.')
+    expect(job.messages[0]).toEqual('The package path `/package.json` in the group `valid_groupname` must be relative and not start with a slash.')
 
     const expectedFiles = {
       'package.json': ['package.json'],
@@ -3892,6 +3895,9 @@ describe('github-event push: monorepo', () => {
     expect(repo.headSha).toEqual('9049f1265b7d61be4a8904a9a27120d2064dab3b')
   })
 
+  /*
+    Joi only returns one message here, because the errors are nested
+  */
   test('monorepo: greenkeeper.json modified by user and it now has invalid groupname & package-path (mgm3)', async () => {
     const configFileContent = {
       groups: {
@@ -3949,7 +3955,7 @@ describe('github-event push: monorepo', () => {
           groups: {
             '#invalid#groupname#': {
               packages: [
-                '@package.json'
+                '/package.json'
               ]
             }
           }
@@ -3984,7 +3990,7 @@ describe('github-event push: monorepo', () => {
     expect(newJob).toBeTruthy()
     const job = newJob.data
     expect(job.name).toEqual('invalid-config-file')
-    expect(job.messages[0]).toEqual('The group name `#invalid#groupname#` is invalid. Group names may only contain alphanumeric characters and underscores (a-zA-Z_).')
+    expect(job.messages[0]).toEqual('The group name `#invalid#groupname#` is invalid. Group names may only contain alphanumeric characters, underscores, dashes and the @ symbol (a-zA-Z_@-).')
 
     const expectedFiles = {
       'package.json': ['package.json'],

--- a/test/jobs/github-event/push.js
+++ b/test/jobs/github-event/push.js
@@ -3415,7 +3415,7 @@ describe('github-event push: monorepo', () => {
     expect(newJob).toBeTruthy()
     const job = newJob.data
     expect(job.name).toEqual('invalid-config-file')
-    expect(job.messages[0]).toEqual('The group name `#invalid#groupname#` is invalid. Group names may only contain alphanumeric characters, underscores, dashes and the @ symbol (a-zA-Z_@-).')
+    expect(job.messages[0]).toEqual('The group name `#invalid#groupname#` is invalid. Group names may only contain alphanumeric characters, underscores and dashes (a-zA-Z_-).')
 
     const expectedFiles = {
       'package.json': ['package.json'],
@@ -3632,7 +3632,7 @@ describe('github-event push: monorepo', () => {
     expect(newJob).toBeTruthy()
     const job = newJob.data
     expect(job.name).toEqual('invalid-config-file')
-    expect(job.messages[0]).toEqual('The group name `#invalid#groupname#` is invalid. Group names may only contain alphanumeric characters, underscores, dashes and the @ symbol (a-zA-Z_@-).')
+    expect(job.messages[0]).toEqual('The group name `#invalid#groupname#` is invalid. Group names may only contain alphanumeric characters, underscores and dashes (a-zA-Z_-).')
 
     const expectedFiles = {
       'package.json': ['package.json'],
@@ -3755,7 +3755,7 @@ describe('github-event push: monorepo', () => {
     expect(newJob).toBeTruthy()
     const job = newJob.data
     expect(job.name).toEqual('invalid-config-file')
-    expect(job.messages[0]).toEqual('The group name `#invalid#groupname#` is invalid. Group names may only contain alphanumeric characters, underscores, dashes and the @ symbol (a-zA-Z_@-).')
+    expect(job.messages[0]).toEqual('The group name `#invalid#groupname#` is invalid. Group names may only contain alphanumeric characters, underscores and dashes (a-zA-Z_-).')
 
     const expectedFiles = {
       'package.json': ['package.json'],
@@ -3990,7 +3990,7 @@ describe('github-event push: monorepo', () => {
     expect(newJob).toBeTruthy()
     const job = newJob.data
     expect(job.name).toEqual('invalid-config-file')
-    expect(job.messages[0]).toEqual('The group name `#invalid#groupname#` is invalid. Group names may only contain alphanumeric characters, underscores, dashes and the @ symbol (a-zA-Z_@-).')
+    expect(job.messages[0]).toEqual('The group name `#invalid#groupname#` is invalid. Group names may only contain alphanumeric characters, underscores and dashes (a-zA-Z_-).')
 
     const expectedFiles = {
       'package.json': ['package.json'],

--- a/test/lib/validate-greenkeeper-json.js
+++ b/test/lib/validate-greenkeeper-json.js
@@ -56,7 +56,7 @@ test('valid without groups', () => {
 test('invalid: groupname has invalid characters', () => {
   const file = {
     groups: {
-      'front-end': {
+      'front!end': {
         ignore: [
           'lodash'
         ],
@@ -74,8 +74,8 @@ test('invalid: groupname has invalid characters', () => {
   }
   const result = validate(file)
   expect(result.error).toBeTruthy()
-  expect(result.error.details[0].message).toMatch(/"front-end" is not allowed/)
-  expect(result.error.details[0].formattedMessage).toMatch('The group name `front-end` is invalid. Group names may only contain alphanumeric characters and underscores (a-zA-Z_).')
+  expect(result.error.details[0].message).toMatch(/"front!end" is not allowed/)
+  expect(result.error.details[0].formattedMessage).toMatch('The group name `front!end` is invalid. Group names may only contain alphanumeric characters, underscores, dashes and the @ symbol (a-zA-Z_@-).')
 })
 
 test('invalid: absolute paths are not allowed', () => {
@@ -95,6 +95,25 @@ test('invalid: absolute paths are not allowed', () => {
   expect(result.error.details[0].context.value).toEqual('/packages/frontend/package.json')
   expect(result.error.details[0].message).toMatch(/fails to match the required pattern/)
   expect(result.error.details[0].formattedMessage).toMatch('The package path `/packages/frontend/package.json` in the group `frontend` must be relative and not start with a slash.')
+})
+
+test('invalid: absolute root path is not allowed', () => {
+  const file = {
+    groups: {
+      frontend: {
+        packages: [
+          '/package.json'
+        ]
+      }
+    }
+  }
+  const result = validate(file)
+  expect(result.error).toBeTruthy()
+  expect(result.error.name).toEqual('ValidationError')
+  expect(result.error.details[0].path).toEqual([ 'groups', 'frontend', 'packages', 0 ])
+  expect(result.error.details[0].context.value).toEqual('/package.json')
+  expect(result.error.details[0].message).toMatch(/fails to match the required pattern/)
+  expect(result.error.details[0].formattedMessage).toMatch('The package path `/package.json` in the group `frontend` must be relative and not start with a slash.')
 })
 
 test('invalid: path is not ending on `package.json`', () => {
@@ -195,7 +214,7 @@ test('invalid: catches invalid chars in otherwise valid package path', () => {
     groups: {
       backend: {
         packages: [
-          'packages/@&|backend/package.json'
+          'packages/#backend/package.json'
         ]
       }
     }
@@ -204,5 +223,5 @@ test('invalid: catches invalid chars in otherwise valid package path', () => {
   expect(result.error).toBeTruthy()
   expect(result.error.name).toEqual('ValidationError')
   expect(result.error.details[0].message).toMatch(/fails to match the required pattern/)
-  expect(result.error.details[0].formattedMessage).toEqual('The package path `packages/@&|backend/package.json` in the group `backend` is invalid. It must be a relative path to a `package.json` file. The path may not start with a slash or an `@`, and it must end in `package.json`.')
+  expect(result.error.details[0].formattedMessage).toEqual('The package path `packages/#backend/package.json` in the group `backend` is invalid. It must be a relative path to a `package.json` file. The path may not start with a slash, and it must end in `package.json`.')
 })


### PR DESCRIPTION
We were preventing `@` and `-` in `package.json` paths in the config, and `-` in the group names. These chars are now allowed. 