### PR TITLE
feat(validate-config-file): error message for malformed JSON

### DIFF
--- a/lib/validate-greenkeeper-json.js
+++ b/lib/validate-greenkeeper-json.js
@@ -24,6 +24,9 @@ function validate (file) {
     errors.error.details.map((e) => {
       // Fall back to the standard Joi message if we don’t have a better one
       e.formattedMessage = e.message
+      if (e.type === 'object.base' && e.path.length === 0) {
+        e.formattedMessage = 'It seems as if your `greenkeeper.json` is not valid JSON. You can check the validity of JSON files with [JSONLint](https://jsonlint.com/), for example.'
+      }
       if (e.type === 'string.regex.base') {
         e.formattedMessage = `The package path \`${e.context.value}\` in the group \`${e.path[1]}\` is invalid. It must be a relative path to a \`package.json\` file. The path may not start with a slash, and it must end in \`package.json\`. Allowed characters for a path are alphanumeric, underscores, dashes and the @ symbol (a-zA-Z_-@).`
       }

--- a/test/lib/validate-greenkeeper-json.js
+++ b/test/lib/validate-greenkeeper-json.js
@@ -251,3 +251,12 @@ test('invalid: no packages and invalid root level key', () => {
   expect(result.error.details[1].message).toMatch(/"badgers" is not allowed/)
   expect(result.error.details[1].formattedMessage).toMatch('The root-level key `badgers` is invalid. If you meant to add a group named `badgers`, please put it in a root-level `groups` object. Valid root-level keys are `groups` and `ignore`.')
 })
+
+test('invalid: malformed JSON', () => {
+  const file = '<huihkhio'
+  const result = validate(file)
+  expect(result.error).toBeTruthy()
+  expect(result.error.name).toEqual('ValidationError')
+  expect(result.error.details[0].message).toEqual('"value" must be an object')
+  expect(result.error.details[0].formattedMessage).toEqual('It seems as if your `greenkeeper.json` is not valid JSON. You can check the validity of JSON files with [JSONLint](https://jsonlint.com/), for example.')
+})


### PR DESCRIPTION
Adds a proper message when the greenkeeper.json isn’t actually JSON. 