### PR TITLE
Fix: 404 on installation added

### DIFF
--- a/jobs/github-event/installation_repositories/added.js
+++ b/jobs/github-event/installation_repositories/added.js
@@ -38,11 +38,9 @@ module.exports = async function ({ installation, repositories_added }) {
           if (error.code === 404) {
             if (number === max404Retries) {
               // ignore and log failure here
-              // console.log('repo not found ' + number + 'th try: giving up')
-              log.warn('repo not found ' + number + 'th try: giving up')
+              log.warn(`repo not found on attempt #${number}: gving up`)
             } else {
-              // console.log('repo not found ' + number + 'th try: retrying')
-              log.warn('repo not found ' + number + 'th try: retrying')
+              log.warn(`repo not found on attempt #${number}: retrying`)
               retry(error)
             }
           } else { // not a 404, throw normally

--- a/test/jobs/github-event/installation_repositories/added.js
+++ b/test/jobs/github-event/installation_repositories/added.js
@@ -5,16 +5,45 @@ const dbs = require('../../../../lib/dbs')
 const removeIfExists = require('../../../helpers/remove-if-exists')
 const repoAdded = require('../../../../jobs/github-event/installation_repositories/added')
 
+beforeEach(() => {
+  nock.cleanAll()
+})
+
+afterAll(async () => {
+  const { repositories } = await dbs()
+  await Promise.all([
+    removeIfExists(repositories, '31', '32')
+  ])
+})
+
+test('github-event installation_repositories but empty list of repos', async () => {
+  const newJobs = await repoAdded({
+    installation: {
+      id: 1,
+      account: {
+        id: 2
+      }
+    },
+    repositories_added: [
+    ]
+  })
+
+  expect(newJobs).toBeFalsy()
+})
+
 test('github-event installation_repositories added', async () => {
   const { repositories } = await dbs()
 
-  nock('https://api.github.com')
+  const httpTraffic = nock('https://api.github.com')
     .post('/installations/1/access_tokens')
+    .optionally()
     .reply(200, {
       token: 'secret'
     })
     .get('/rate_limit')
+    .optionally()
     .reply(200, {})
+
     .get('/repos/bar/repo1')
     .reply(200, {
       id: 31,
@@ -64,11 +93,162 @@ test('github-event installation_repositories added', async () => {
   expect(repo.private).toBeTruthy()
   expect(repo.fork).toBeFalsy()
   expect(repo.hasIssues).toBeTruthy()
+  expect(httpTraffic.isDone()).toBeTruthy()
+  expect(httpTraffic.pendingMocks().length).toEqual(0)
 })
 
-afterAll(async () => {
+test('github-event installation_repositories added with intermittent 404s', async () => {
   const { repositories } = await dbs()
-  await Promise.all([
-    removeIfExists(repositories, '31', '32')
+
+  const httpTraffic = nock('https://api.github.com')
+    .post('/installations/1/access_tokens')
+    .optionally()
+    .reply(200, {
+      token: 'secret'
+    })
+    .get('/rate_limit')
+    .optionally()
+    .reply(200, {})
+    .get('/repos/bar/repo1')
+    .reply(404, 'not found')
+    .get('/repos/bar/repo1')
+    .reply(200, {
+      id: 31,
+      full_name: 'bar/repo1',
+      private: true,
+      fork: false,
+      has_issues: true
+    })
+    .get('/repos/bar/repo2')
+    .reply(200, {
+      id: 32,
+      full_name: 'bar/repo2',
+      private: false,
+      fork: false,
+      has_issues: true
+    })
+  const newJobs = await repoAdded({
+    installation: {
+      id: 1,
+      account: {
+        id: 2
+      }
+    },
+    repositories_added: [
+      { id: 31, full_name: 'bar/repo1' },
+      { id: 32, full_name: 'bar/repo2' }
+    ]
+  })
+
+  expect(newJobs).toHaveLength(2)
+
+  const repos = await Promise.all([
+    repositories.get('31'),
+    repositories.get('32')
   ])
+  expect(_.uniq(_.map(newJobs, 'data.name'))).toContain('create-initial-branch')
+
+  newJobs.forEach((job, i) => {
+    expect(job.data.accountId).toEqual('2')
+  })
+
+  const [repo] = repos
+  expect(repo._id).toEqual('31')
+  expect(repo.enabled).toBeFalsy()
+  expect(repo.accountId).toEqual('2')
+  expect(repo.fullName).toEqual('bar/repo1')
+  expect(repo.private).toBeTruthy()
+  expect(repo.fork).toBeFalsy()
+  expect(repo.hasIssues).toBeTruthy()
+  expect(httpTraffic.isDone()).toBeTruthy()
+  expect(httpTraffic.pendingMocks().length).toEqual(0)
+})
+
+test('github-event installation_repositories added with too many 404s', async () => {
+  expect.assertions(2)
+
+  const httpTraffic = nock('https://api.github.com')
+    .post('/installations/1/access_tokens')
+    .optionally()
+    .reply(200, {
+      token: 'secret'
+    })
+    .get('/rate_limit')
+    .optionally()
+    .reply(200, {})
+
+    .get('/repos/bar/repo1')
+    .reply(404, 'not found')
+
+    .get('/repos/bar/repo1')
+    .reply(404, 'not found')
+
+    .get('/repos/bar/repo1')
+    .reply(404, 'not found')
+
+    .get('/repos/bar/repo1')
+    .reply(404, 'not found')
+
+    .get('/repos/bar/repo1')
+    .reply(404, 'not found')
+
+  try {
+    await repoAdded({
+      installation: {
+        id: 1,
+        account: {
+          id: 2
+        }
+      },
+      repositories_added: [
+        { id: 31, full_name: 'bar/repo1' },
+        { id: 32, full_name: 'bar/repo2' }
+      ]
+    })
+
+    // this should never be reached
+    expect(false).toBeTruthy()
+  } catch (e) {
+    expect(httpTraffic.isDone()).toBeTruthy()
+    expect(httpTraffic.pendingMocks().length).toEqual(0)
+  }
+})
+
+test('github-event installation_repositories added with a non 404 error', async () => {
+  expect.assertions(3)
+
+  const httpTraffic = nock('https://api.github.com')
+    .post('/installations/1/access_tokens')
+    .optionally()
+    .reply(200, {
+      token: 'secret'
+    })
+    .get('/rate_limit')
+    .optionally()
+    .reply(200, {})
+
+    .get('/repos/bar/repo1')
+    .reply(500, 'server error')
+
+  try {
+    await repoAdded({
+      installation: {
+        id: 1,
+        account: {
+          id: 2
+        }
+      },
+      repositories_added: [
+        { id: 31, full_name: 'bar/repo1' },
+        { id: 32, full_name: 'bar/repo2' }
+      ]
+    })
+
+    // this should never be reached
+    expect(false).toBeTruthy()
+  } catch (e) {
+    expect(httpTraffic.isDone()).toBeTruthy()
+    expect(httpTraffic.pendingMocks().length).toEqual(0)
+    expect(e.code).toEqual(500)
+  }
 })


### PR DESCRIPTION
feat: retry 404 errors on `repos.get()`

adds logging so we can find out why we are getting a 404 here. If the case is that we are getting a notification about this before we actually do have access, we retry with the usual 5/3000 policy.

If we can’t get a repo info in five tries, we ignore the error and log the result.


feat: test new 404 retry behaviour and improve tests.

Test improvements:

- added test cases to raise coverage to 100%
- expect empty `pendingMocks` to ensure tests are written correctly
- use nock-local instance variables for tests
- make token requests optional, so tests can be run together and in isolation. The reason here is caching that we can not override from the test setup.
