### PR TITLE
Fix/monorepo misc

### DIFF
--- a/content/initial-pr.js
+++ b/content/initial-pr.js
@@ -125,9 +125,18 @@ There is a collection of [frequently asked questions](https://greenkeeper.io/faq
 
 // needs to handle files as an array of arrays!
 function hasLockFileText (files) {
-  const lockFiles = _.pick(files, ['package-lock.json', 'npm-shrinkwrap.json', 'yarn.lock'])
-  const lockFile = _.findKey(lockFiles)
-  if (!lockFile) return
+  if (!files) return
+  const lockFiles = ['package-lock.json', 'npm-shrinkwrap.json', 'yarn.lock'].filter((key) => {
+    if (_.isArray(files[key]) && files[key].length) {
+      return true
+    }
+    if (files[key] === true) {
+      return true
+    }
+    return false
+  })
+  if (lockFiles.length === 0) return
+  const lockFile = lockFiles[0]
   return md`⚠️ Greenkeeper has found a ${md.code(lockFile)} file in this repository. Please use [greenkeeper-lockfile](https://github.com/greenkeeperio/greenkeeper-lockfile) to make sure this gets updated as well.`
 }
 

--- a/jobs/create-initial-branch.js
+++ b/jobs/create-initial-branch.js
@@ -183,7 +183,8 @@ module.exports = async function ({ repositoryId }) {
         const greenkeeperJSON = {
           groups: defaultGroups
         }
-        return JSON.stringify(greenkeeperJSON, null, 2)
+        // greenkeeper.json must end with a newline
+        return JSON.stringify(greenkeeperJSON, null, 2) + '\n'
       },
       create: true
     }
@@ -203,7 +204,8 @@ module.exports = async function ({ repositoryId }) {
 
       // Replace the transform that generates the default group with one that updates existing groups
       greenkeeperJSONTransform.transform = () => {
-        return JSON.stringify(greenkeeperConfigFile, null, 2)
+        // greenkeeper.json must end with a newline
+        return JSON.stringify(greenkeeperConfigFile, null, 2) + '\n'
       }
       // Don’t create this file because it already exists
       delete greenkeeperJSONTransform.create

--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -10,7 +10,8 @@ module.exports = repository => {
     {}
   )
 
-  return _.defaultsDeep(config, {
+  // Make a copy instead of mutating the original repoDoc config!
+  return _.defaultsDeep(JSON.parse(JSON.stringify(config)), {
     label: 'greenkeeper',
     branchPrefix: 'greenkeeper/',
     ignore: [],

--- a/test/jobs/create-initial-branch.js
+++ b/test/jobs/create-initial-branch.js
@@ -405,7 +405,7 @@ describe('create initial branch', () => {
       '@finnpauls/dep': '1.0.0',
       '@finnpauls/dep2': '1.0.0'
     }
-    expect.assertions(20)
+    expect.assertions(21)
 
     nock('https://api.github.com')
       .post('/installations/137/access_tokens')
@@ -515,13 +515,16 @@ describe('create initial branch', () => {
       expect(newReadme).toMatch(/https:\/\/badges.greenkeeper.io\/finnp\/test.svg/)
       expect(transforms.length).toEqual(5)
       expect(transforms[0].path).toEqual('greenkeeper.json')
-      expect(JSON.parse(transforms[0].transform())).toEqual({
+      const greenkeeperConfigTransformResult = transforms[0].transform()
+      expect(JSON.parse(greenkeeperConfigTransformResult)).toEqual({
         groups: {
           default: {
             packages: ['package.json', 'frontend/package.json']
           }
         }
       })
+      // greenkeeper.json must end with a newline
+      expect(greenkeeperConfigTransformResult.substr(greenkeeperConfigTransformResult.length - 1, 1)).toEqual('\n')
       expect(transforms[1].path).toEqual('frontend/package.json')
       expect(JSON.parse(transforms[1].transform(JSON.stringify({ devDependencies })))).toEqual({
         'devDependencies': {
@@ -604,7 +607,7 @@ describe('create initial branch', () => {
       '@finnpauls/dep2': '1.0.0'
     }
 
-    expect.assertions(18)
+    expect.assertions(19)
 
     nock('https://api.github.com')
       .post('/installations/137/access_tokens')
@@ -733,8 +736,9 @@ describe('create initial branch', () => {
       // The `empty` group should disappear completely, since it no longer contains any files
       // The `frontend` group should not contain `this-file-no-longer-exists/package.json`, since that file
       // is no longer in the repo
-      const transformedConfigFile = JSON.parse(transforms[0].transform())
-      expect(transformedConfigFile.groups).toMatchObject({
+      const transformedConfigFile = transforms[0].transform()
+      const parsedConfigFile = JSON.parse(transformedConfigFile)
+      expect(parsedConfigFile.groups).toMatchObject({
         build: {
           packages: [
             'package.json'
@@ -751,7 +755,9 @@ describe('create initial branch', () => {
           ]
         }
       })
-      expect(transformedConfigFile.ignore).toEqual(['eslint'])
+      // greenkeeper.json must end with a newline
+      expect(transformedConfigFile.substr(transformedConfigFile.length - 1, 1)).toEqual('\n')
+      expect(parsedConfigFile.ignore).toEqual(['eslint'])
       expect(transforms.length).toEqual(6)
 
       return '1234abcd'

--- a/test/jobs/create-initial-branch.js
+++ b/test/jobs/create-initial-branch.js
@@ -607,7 +607,7 @@ describe('create initial branch', () => {
       '@finnpauls/dep2': '1.0.0'
     }
 
-    expect.assertions(19)
+    expect.assertions(20)
 
     nock('https://api.github.com')
       .post('/installations/137/access_tokens')
@@ -738,6 +738,8 @@ describe('create initial branch', () => {
       // is no longer in the repo
       const transformedConfigFile = transforms[0].transform()
       const parsedConfigFile = JSON.parse(transformedConfigFile)
+      // Check that we don’t add Greenkeeper system defaults to the actual greenkeeper.json file
+      expect(parsedConfigFile.commitMessages).toBeFalsy()
       expect(parsedConfigFile.groups).toMatchObject({
         build: {
           packages: [


### PR DESCRIPTION
### Fixes: 
`create-initial-branch`: iterate over all package.jsons
`create-initial-branch`: greenkeeper.json must end with newline
`get-config`: don‘t mutate original config in repo doc