### PR TITLE
fix(create-initial-branch): use appropriate commit message

### DIFF
--- a/jobs/create-initial-branch.js
+++ b/jobs/create-initial-branch.js
@@ -208,6 +208,7 @@ module.exports = async function ({ repositoryId }) {
       const updatedGreenkeeperConfigFile = updatedGreenkeeperConfigMeta.greenkeeperConfigFile
       log.info('updating existing greenkeeper config', {greekeeperJson: greenkeeperConfigFile, updatedGreenkeeperJson: updatedGreenkeeperConfigFile})
       // Replace the transform that generates the default group with one that updates existing groups
+      greenkeeperJSONTransform.message = getMessage(config.commitMessages, 'updateConfigFile')
       greenkeeperJSONTransform.transform = () => {
         // greenkeeper.json must end with a newline
         return JSON.stringify(updatedGreenkeeperConfigFile, null, 2) + '\n'

--- a/lib/default-commit-messages.js
+++ b/lib/default-commit-messages.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-template-curly-in-string */
 const defaultCommitMessages = {
   addConfigFile: 'chore: add Greenkeeper config file',
+  updateConfigFile: 'chore: update Greenkeeper config file',
   initialBadge: 'docs(readme): add Greenkeeper badge',
   initialDependencies: 'chore(package): update dependencies',
   initialBranches: 'chore(travis): whitelist greenkeeper branches',

--- a/test/jobs/create-initial-branch.js
+++ b/test/jobs/create-initial-branch.js
@@ -405,7 +405,7 @@ describe('create initial branch', () => {
       '@finnpauls/dep': '1.0.0',
       '@finnpauls/dep2': '1.0.0'
     }
-    expect.assertions(21)
+    expect.assertions(22)
 
     nock('https://api.github.com')
       .post('/installations/137/access_tokens')
@@ -515,6 +515,7 @@ describe('create initial branch', () => {
       expect(newReadme).toMatch(/https:\/\/badges.greenkeeper.io\/finnp\/test.svg/)
       expect(transforms.length).toEqual(5)
       expect(transforms[0].path).toEqual('greenkeeper.json')
+      expect(transforms[0].message).toEqual('chore: add Greenkeeper config file')
       const greenkeeperConfigTransformResult = transforms[0].transform()
       expect(JSON.parse(greenkeeperConfigTransformResult)).toEqual({
         groups: {
@@ -566,7 +567,7 @@ describe('create initial branch', () => {
     })
   })
 
-  test.only('create pull request for monorepo and update existing greenkeeper.json', async () => {
+  test('create pull request for monorepo and update existing greenkeeper.json', async () => {
     // We also simulate that the greenkeeper.json info in our repoDoc is out of date and
     // should be overwritten with what is in the actual file on github.
     const githubConfigFileContent = {
@@ -631,7 +632,7 @@ describe('create initial branch', () => {
       '@finnpauls/dep2': '1.0.0'
     }
 
-    expect.assertions(20)
+    expect.assertions(21)
 
     nock('https://api.github.com')
       .post('/installations/137/access_tokens')
@@ -783,6 +784,7 @@ describe('create initial branch', () => {
       })
       // greenkeeper.json must end with a newline
       expect(transformedConfigFile.substr(transformedConfigFile.length - 1, 1)).toEqual('\n')
+      expect(transforms[0].message).toEqual('chore: update Greenkeeper config file')
       expect(parsedConfigFile.ignore).toEqual(['eslint'])
       expect(transforms.length).toEqual(6)
 

--- a/test/lib/get-config.js
+++ b/test/lib/get-config.js
@@ -17,6 +17,7 @@ test('get default config', () => {
     ignore: [],
     commitMessages: {
       addConfigFile: 'chore: add Greenkeeper config file',
+      updateConfigFile: 'chore: update Greenkeeper config file',
       initialBadge: 'docs(readme): add Greenkeeper badge',
       initialDependencies: 'chore(package): update dependencies',
       initialBranches: 'chore(travis): whitelist greenkeeper branches',
@@ -57,6 +58,7 @@ test('get config from  root greenkeeper section', () => {
     ignore: [],
     commitMessages: {
       addConfigFile: 'chore: add Greenkeeper config file',
+      updateConfigFile: 'chore: update Greenkeeper config file',
       initialBadge: 'docs(readme): add Greenkeeper badge',
       initialDependencies: 'chore(package): update dependencies',
       initialBranches: 'chore(travis): whitelist greenkeeper branches',
@@ -98,6 +100,7 @@ test('get custom commit message', () => {
     ignore: [],
     commitMessages: {
       addConfigFile: 'chore: add Greenkeeper config file',
+      updateConfigFile: 'chore: update Greenkeeper config file',
       initialBadge: 'HELLO Greenkeeper badge',
       initialDependencies: 'chore(package): update dependencies',
       initialBranches: 'chore(travis): whitelist greenkeeper branches',


### PR DESCRIPTION
when editing the greenkeeper.json


**before**: it would edit but still commit it with "chore: add Greenkeeper config file"
**now**: it edits and commits with "chore: edit Greenkeeper config file"