### PR TITLE
feat: test on node 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache:
   - $HOME/.npm
 notifications:
   email: false
-node_js: 7
+node_js: 8
 before_install:
 - npm install -g npm@5.2.0
 install: npm install

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mhart/alpine-node:7
+FROM mhart/alpine-node:8
 
 ARG PKG_VERSION
 ADD greenkeeper-jobs-${PKG_VERSION}.tgz ./

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "standard": "^10.0.2"
   },
   "engines": {
-    "node": ">=7.6"
+    "node": "8"
   },
   "license": "Apache-2.0",
   "jest": {


### PR DESCRIPTION
Todo:
- [x] test https://github.com/greenkeeperio/greenkeeper with Node 8
- [x] test https://github.com/greenkeeperio/hooks with Node 8 https://github.com/greenkeeperio/hooks/pull/31
- [x] test https://github.com/greenkeeperio/changes with Node 8 https://github.com/greenkeeperio/changes/pull/20
- [x] test https://github.com/greenkeeperio/log with Node 8 https://github.com/greenkeeperio/gk-log/pull/15
- [x] test https://github.com/greenkeeperio/badges with Node 8 https://github.com/greenkeeperio/badges/pull/32
- [x] ~test https://github.com/greenkeeperio/urls with Node 8~ no need

* * *

not used by enterprise, but we should get them all updated

- [x] test neighbourhoodie/gk-account
- [x] neighoburhoodie/gk-wt-tasks
- [x] any missing?

Test procedure:
- [x] read up on changes between Node 7 and Node 8
- [x] review above repos for where significant changes affect our code
- [x] test locally
- [x] create test branches
- [ ] test on staging
- [ ] deploy