### PR TITLE
fix: report greenkeeper.json parse errors

### DIFF
--- a/jobs/github-event/push.js
+++ b/jobs/github-event/push.js
@@ -60,16 +60,20 @@ module.exports = async function (data) {
   try {
     await updateRepoDoc({installationId: installation.id, doc: repoDoc, log})
   } catch (e) {
-    console.log(e)
-    return invalidConfigFile({
-      repoDoc,
-      config,
-      repositories,
-      repository,
-      repositoryId,
-      details: [{ formattedMessage: e.message }],
-      log
-    })
+    if (e.name && e.name === 'GKConfigFileParseError') {
+      log.warn('updateRepoDoc failed because of an invalid config file')
+      return invalidConfigFile({
+        repoDoc,
+        config,
+        repositories,
+        repository,
+        repositoryId,
+        details: [{ formattedMessage: e.message }],
+        log
+      })
+    }
+    log.warn('updateRepoDoc failed, we do not know why', {exception: e})
+    throw e
   }
   const pkg = _.get(repoDoc, ['packages'])
   // If there are no more packages in the repoDoc, disable the repo, which means it will also stop being counted for billing

--- a/jobs/github-event/push.js
+++ b/jobs/github-event/push.js
@@ -67,7 +67,7 @@ module.exports = async function (data) {
 
   if (hasRelevantConfigFileChanges(data.commits)) {
     const configValidation = validate(repoDoc.greenkeeper)
-    if (configValidation.error) {
+    if (repoDoc.greenkeeper === '__gk_parse_error' || configValidation.error) {
       log.warn('validation of greenkeeper.json failed', {error: configValidation.error.details, greenkeeperJson: repoDoc.greenkeeper})
       // reset greenkeeper config in repoDoc to the previous working version and start an 'invalid-config-file' job
       _.set(repoDoc, ['greenkeeper'], config)

--- a/jobs/github-event/push.js
+++ b/jobs/github-event/push.js
@@ -57,7 +57,20 @@ module.exports = async function (data) {
   // always put package.jsons in the repoDoc (new & old)
   // if remove event: delete key of package.json
   const oldPkg = _.get(repoDoc, ['packages'])
-  await updateRepoDoc({installationId: installation.id, doc: repoDoc, log})
+  try {
+    await updateRepoDoc({installationId: installation.id, doc: repoDoc, log})
+  } catch (e) {
+    console.log(e)
+    return invalidConfigFile({
+      repoDoc,
+      config,
+      repositories,
+      repository,
+      repositoryId,
+      details: [{ formattedMessage: e.message }],
+      log
+    })
+  }
   const pkg = _.get(repoDoc, ['packages'])
   // If there are no more packages in the repoDoc, disable the repo, which means it will also stop being counted for billing
   if (_.isEmpty(pkg)) {
@@ -67,24 +80,16 @@ module.exports = async function (data) {
 
   if (hasRelevantConfigFileChanges(data.commits)) {
     const configValidation = validate(repoDoc.greenkeeper)
-    if (repoDoc.greenkeeper === '__gk_parse_error' || configValidation.error) {
-      log.warn('validation of greenkeeper.json failed', {error: configValidation.error.details, greenkeeperJson: repoDoc.greenkeeper})
-      // reset greenkeeper config in repoDoc to the previous working version and start an 'invalid-config-file' job
-      _.set(repoDoc, ['greenkeeper'], config)
-      await updateDoc(repositories, repository, repoDoc)
-      // If the config file is invalid, open an issue with validation errors and don’t do anything else in this file:
-      // - no initial branch should be created (?)
-      // - no initial subgroup branches should (or can be) be created
-      // - no branches need to be deleted (we can’t be sure the changes are valid)
-      return {
-        data: {
-          name: 'invalid-config-file',
-          messages: _.map(configValidation.error.details, 'formattedMessage'),
-          errors: configValidation.error.details,
-          repositoryId,
-          accountId: repoDoc.accountId
-        }
-      }
+    if (configValidation.error) {
+      return invalidConfigFile({
+        repoDoc,
+        config,
+        repositories,
+        repository,
+        repositoryId,
+        details: configValidation.error.details,
+        log
+      })
     }
   }
 
@@ -165,6 +170,27 @@ module.exports = async function (data) {
       .value()
   }
   log.success('success')
+}
+
+async function invalidConfigFile ({repoDoc, config, repositories, repository, repositoryId, details, log}) {
+  log.warn('validation of greenkeeper.json failed', {error: details, greenkeeperJson: repoDoc.greenkeeper})
+  // reset greenkeeper config in repoDoc to the previous working version and start an 'invalid-config-file' job
+  _.set(repoDoc, ['greenkeeper'], config)
+  await updateDoc(repositories, repository, repoDoc)
+  // If the config file is invalid, open an issue with validation errors and don’t do anything else in this file:
+  // - no initial branch should be created (?)
+  // - no initial subgroup branches should (or can be) be created
+  // - no branches need to be deleted (we can’t be sure the changes are valid)
+
+  return {
+    data: {
+      name: 'invalid-config-file',
+      messages: _.map(details, 'formattedMessage'),
+      errors: details,
+      repositoryId,
+      accountId: repoDoc.accountId
+    }
+  }
 }
 
 function updateDoc (repositories, repository, repoDoc) {

--- a/lib/diff-greenkeeper-json.js
+++ b/lib/diff-greenkeeper-json.js
@@ -2,6 +2,7 @@ const _ = require('lodash')
 
 module.exports = function (oldFile, newFile) {
   const changes = {added: [], removed: [], modified: []}
+  if (newFile.__gk_error) return changes
   if (!newFile || !oldFile) return changes
   // greenkeeper.json was deleted
   if (_.isEmpty(newFile) && oldFile.groups) {

--- a/lib/get-files.js
+++ b/lib/get-files.js
@@ -111,9 +111,11 @@ async function getGreenkeeperConfigFile (installationId, fullName, log = console
       parsedConfigFile = JSON.parse(Buffer.from(greenkeeperConfigFile.content, 'base64'))
     } catch (e) {
       log.error('Could not parse greenkeeper.json', {error: e})
+      return '__gk_parse_error'
     }
   } catch (e) {
     log.error('Could not get greenkeeper.json from GitHub', {error: e})
+    return '__gk_parse_error'
   }
 
   return parsedConfigFile

--- a/lib/get-files.js
+++ b/lib/get-files.js
@@ -111,11 +111,18 @@ async function getGreenkeeperConfigFile (installationId, fullName, log = console
       parsedConfigFile = JSON.parse(Buffer.from(greenkeeperConfigFile.content, 'base64'))
     } catch (e) {
       log.error('Could not parse greenkeeper.json', {error: e})
-      return '__gk_parse_error'
+      // throw error, so we can raise an issue
+      throw new Error('could not parse greenkeeper.json')
     }
   } catch (e) {
+    if (e.code === 404) {
+      log.error('No greenkeeper.json in repo')
+      // return empty object, so job can continue
+      return {}
+    }
     log.error('Could not get greenkeeper.json from GitHub', {error: e})
-    return '__gk_parse_error'
+    // return empty object, so job can continue
+    return {}
   }
 
   return parsedConfigFile

--- a/lib/get-files.js
+++ b/lib/get-files.js
@@ -103,28 +103,24 @@ async function getGreenkeeperConfigFile (installationId, fullName, log = console
   const ghqueue = githubQueue(installationId)
   const [owner, repo] = fullName.split('/')
   const path = 'greenkeeper.json'
+  let greenkeeperConfigFile = {}
   let parsedConfigFile = {}
   log.info('Fetching greenkeeper.json from GitHub', {path, owner, repo})
-  try {
-    const greenkeeperConfigFile = await getGithubFile(ghqueue, { path, owner, repo })
-    try {
-      parsedConfigFile = JSON.parse(Buffer.from(greenkeeperConfigFile.content, 'base64'))
-    } catch (e) {
-      log.error('Could not parse greenkeeper.json', {error: e})
-      // throw error, so we can raise an issue
-      const error = new Error('could not parse greenkeeper.json')
-      error.name = 'GKConfigFileParseError'
-      throw error
-    }
-  } catch (e) {
-    if (e.code === 404) {
-      log.error('No greenkeeper.json in repo')
-      // return empty object, so job can continue
-      return {}
-    }
-    log.error('Could not get greenkeeper.json from GitHub', {error: e})
+  greenkeeperConfigFile = await getGithubFile(ghqueue, { path, owner, repo })
+  if (!greenkeeperConfigFile.content) {
+    log.info('No greenkeeper.json in repo')
     // return empty object, so job can continue
     return {}
+  }
+
+  try {
+    parsedConfigFile = JSON.parse(Buffer.from(greenkeeperConfigFile.content, 'base64'))
+  } catch (e) {
+    log.error('Could not parse greenkeeper.json', {error: e})
+    // throw error, so we can raise an issue
+    const error = new Error('Could not parse `greenkeeper.json`, it appears to not be a valid JSON file.')
+    error.name = 'GKConfigFileParseError'
+    throw error
   }
 
   return parsedConfigFile

--- a/lib/get-files.js
+++ b/lib/get-files.js
@@ -112,7 +112,9 @@ async function getGreenkeeperConfigFile (installationId, fullName, log = console
     } catch (e) {
       log.error('Could not parse greenkeeper.json', {error: e})
       // throw error, so we can raise an issue
-      throw new Error('could not parse greenkeeper.json')
+      const error = new Error('could not parse greenkeeper.json')
+      error.name = 'GKConfigFileParseError'
+      throw error
     }
   } catch (e) {
     if (e.code === 404) {

--- a/test/jobs/github-event/installation/created.js
+++ b/test/jobs/github-event/installation/created.js
@@ -5,9 +5,10 @@ const dbs = require('../../../../lib/dbs')
 const removeIfExists = require('../../../helpers/remove-if-exists')
 const createInstallation = require('../../../../jobs/github-event/installation/created')
 
+jest.setTimeout(10000)
+
 test('github-event installation created', async () => {
   const { installations, repositories } = await dbs()
-
   nock('https://api.github.com')
     .post('/installations/1/access_tokens')
     .reply(200, {

--- a/test/jobs/github-event/push.js
+++ b/test/jobs/github-event/push.js
@@ -9,6 +9,16 @@ const { cleanCache, requireFresh } = require('../../helpers/module-cache-helpers
 const pathToWorker = require.resolve('../../../jobs/github-event/push')
 jest.setTimeout(10000)
 
+const configFileContent = {
+  groups: {
+    default: {
+      packages: [
+        'package.json'
+      ]
+    }
+  }
+}
+
 describe('github-event push', async () => {
   beforeEach(() => {
     jest.resetModules()
@@ -45,6 +55,13 @@ describe('github-event push', async () => {
       })
       .get('/rate_limit')
       .reply(200, {})
+      .get('/repos/finn/disabled/contents/greenkeeper.json')
+      .reply(200, {
+        type: 'file',
+        path: 'greenkeeper.json',
+        name: 'greenkeeper.json',
+        content: Buffer.from(JSON.stringify(configFileContent)).toString('base64')
+      })
       .get('/repos/finn/disabled/contents/package.json')
       .reply(200, {
         path: 'package.json',
@@ -116,6 +133,16 @@ describe('github-event push', async () => {
   test('monorepo: subdirectory package.json was modified (555)', async () => {
     const { repositories } = await dbs()
 
+    const myConfigFileContent = {
+      groups: {
+        frontend: {
+          packages: [
+            'packages/frontend/package.json'
+          ]
+        }
+      }
+    }
+
     await repositories.put({
       _id: '555',
       fullName: 'hans/monorepo',
@@ -142,15 +169,6 @@ describe('github-event push', async () => {
     })
 
     const githubPush = requireFresh(pathToWorker)
-    const configFileContent = {
-      groups: {
-        frontend: {
-          packages: [
-            'packages/frontend/package.json'
-          ]
-        }
-      }
-    }
 
     nock('https://api.github.com')
       .post('/installations/11/access_tokens')
@@ -164,7 +182,7 @@ describe('github-event push', async () => {
         type: 'file',
         path: 'greenkeeper.json',
         name: 'greenkeeper.json',
-        content: Buffer.from(JSON.stringify(configFileContent)).toString('base64')
+        content: Buffer.from(JSON.stringify(myConfigFileContent)).toString('base64')
       })
       .get('/repos/hans/monorepo/contents/packages/frontend/package.json')
       .reply(200, {
@@ -239,7 +257,7 @@ describe('github-event push', async () => {
   test('monorepo: subdirectory package.json, which is not listed in the config, was modified (555)', async () => {
     const { repositories } = await dbs()
     const githubPush = requireFresh(pathToWorker)
-    const configFileContent = {
+    const myConfigFileContent = {
       groups: {
         frontend: {
           packages: [
@@ -248,7 +266,6 @@ describe('github-event push', async () => {
         }
       }
     }
-
     nock('https://api.github.com')
       .post('/installations/11/access_tokens')
       .reply(200, {
@@ -261,7 +278,7 @@ describe('github-event push', async () => {
         type: 'file',
         path: 'greenkeeper.json',
         name: 'greenkeeper.json',
-        content: Buffer.from(JSON.stringify(configFileContent)).toString('base64')
+        content: Buffer.from(JSON.stringify(myConfigFileContent)).toString('base64')
       })
       .get('/repos/hans/monorepo/contents/packages/frontend/package.json')
       .reply(200, {
@@ -375,6 +392,8 @@ describe('github-event push', async () => {
       })
       .get('/rate_limit')
       .reply(200, {})
+      .get('/repos/finn/test/contents/greenkeeper.json')
+      .reply(404, {})
       .get('/repos/finn/test/contents/package.json')
       .reply(200, {
         path: 'package.json',
@@ -487,6 +506,8 @@ describe('github-event push', async () => {
       })
       .get('/rate_limit')
       .reply(200, {})
+      .get('/repos/finn/test/contents/greenkeeper.json')
+      .reply(404, {})
       .get('/repos/finn/test/contents/package.json')
       .reply(200, {
         path: 'package.json',
@@ -627,6 +648,14 @@ describe('github-event push', async () => {
       .get('/rate_limit')
       .optionally()
       .reply(200, {})
+      .get('/repos/finn/test/contents/greenkeeper.json')
+      .reply(200, {
+        type: 'file',
+        path: 'greenkeeper.json',
+        name: 'greenkeeper.json',
+        content: Buffer.from(JSON.stringify(configFileContent)).toString('base64')
+      })
+
       .get('/repos/finn/test/contents/package.json')
       .reply(200, () => {
         // should not request package.json
@@ -679,6 +708,13 @@ describe('github-event push', async () => {
       .get('/rate_limit')
       .optionally()
       .reply(200, {})
+      .get('/repos/finn/enabled/contents/greenkeeper.json')
+      .reply(200, {
+        type: 'file',
+        path: 'greenkeeper.json',
+        name: 'greenkeeper.json',
+        content: Buffer.from(JSON.stringify(configFileContent)).toString('base64')
+      })
       .get('/repos/finn/test/contents/package.json')
       .reply(404, {})
 
@@ -736,6 +772,13 @@ describe('github-event push', async () => {
       .get('/rate_limit')
       .optionally()
       .reply(200, {})
+      .get('/repos/finn/private/contents/greenkeeper.json')
+      .reply(200, {
+        type: 'file',
+        path: 'greenkeeper.json',
+        name: 'greenkeeper.json',
+        content: Buffer.from(JSON.stringify(configFileContent)).toString('base64')
+      })
       .get('/repos/finn/private/contents/package.json')
       .reply(404, {})
 
@@ -796,6 +839,14 @@ describe('github-event push', async () => {
       .get('/rate_limit')
       .optionally()
       .reply(200, {})
+      .get('/repos/finn/private/contents/greenkeeper.json')
+      .reply(200, {
+        type: 'file',
+        path: 'greenkeeper.json',
+        name: 'greenkeeper.json',
+        content: Buffer.from(JSON.stringify(configFileContent)).toString('base64')
+      })
+
       .get('/repos/finn/private/contents/package.json')
       .reply(404, {})
 
@@ -3079,7 +3130,7 @@ describe('github-event push: monorepo', () => {
   })
 
   test('monorepo: greenkeeper.json deleted with existing branches (1117)', async () => {
-    const configFileContent = {
+    const configFileContentLocal = {
       groups: {
         frontend: {
           packages: [
@@ -3114,7 +3165,7 @@ describe('github-event push: monorepo', () => {
               }
             }
           },
-          greenkeeper: configFileContent
+          greenkeeper: configFileContentLocal
         },
         {
           _id: '1117:branch:1234abca',


### PR DESCRIPTION
~bit ugly 👼~

no longer ugly 😎 

fix(push): report malformed greenkeeper.json error on GitHub push
This one required a refactor of the GitHub push job, so it is a
little bit more involved.

Before, getGreenkeeperConfigFile was swallowing exceptions for
getting the file from GitHub and for parsing it.

Now, a parse error throws an error that in turn causes the
invalid-config-file job as per #678 and #672.

Also, GitHub errors now cause log entries, and return an empty
object, like the earlier default behaviour.
