### PR TITLE
refactor(test): move afterEach() to top of test file

### DIFF
--- a/test/jobs/cancel-stripe-subscription.js
+++ b/test/jobs/cancel-stripe-subscription.js
@@ -8,6 +8,13 @@ const cancelStripeSubscription = require('../../jobs/cancel-stripe-subscription'
 nock.disableNetConnect()
 nock.enableNetConnect('localhost')
 
+afterAll(async () => {
+  const { payments } = await dbs()
+  await Promise.all([
+    removeIfExists(payments, '123')
+  ])
+})
+
 test('Cancel Stripe Subscription', async () => {
   const { payments } = await dbs()
   expect.assertions(3)
@@ -38,11 +45,4 @@ test('Cancel Stripe Subscription', async () => {
   const payment = await payments.get('123')
   expect(payment.stripeItemId).toBeNull()
   expect(payment.stripeSubscriptionId).toBeNull()
-})
-
-afterAll(async () => {
-  const { payments } = await dbs()
-  await Promise.all([
-    removeIfExists(payments, '123')
-  ])
 })

--- a/test/jobs/create-initial-pr.js
+++ b/test/jobs/create-initial-pr.js
@@ -116,6 +116,16 @@ describe('create-initial-pr', async () => {
     })
   })
 
+  afterAll(async () => {
+    const { repositories, payments } = await dbs()
+
+    await Promise.all([
+      removeIfExists(payments, '123free', '123opensource', '123stripe', '123team', '123business'),
+      removeIfExists(repositories, '42', ' 42b', '43', '44', '44b', '45', '46',
+      'repoId:branch:1234abcd', '47', '48', '49', 'repoId:branch:monorepo1', 'repoId:branch:monorepo2', 'repoId:branch:closes-issues')
+    ])
+  })
+
   test('create pr for account with `free` plan', async () => {
     const createInitial = requireFresh('../../jobs/create-initial-pr')
     const { repositories } = await dbs()
@@ -863,14 +873,5 @@ describe('create-initial-pr', async () => {
       installationId: 11,
       accountId: '123free'
     })
-  })
-
-  afterAll(async () => {
-    const { repositories, payments } = await dbs()
-
-    await Promise.all([
-      removeIfExists(payments, '123free', '123opensource', '123stripe', '123team', '123business'),
-      removeIfExists(repositories, '42', ' 42b', '43', '44', '44b', '45', '46', 'repoId:branch:1234abcd', '47', '48', '49', '50', 'repoId:branch:monorepo1', 'repoId:branch:monorepo2', 'repoId:branch:closes-issues')
-    ])
   })
 })

--- a/test/jobs/create-initial-pr.js
+++ b/test/jobs/create-initial-pr.js
@@ -122,7 +122,7 @@ describe('create-initial-pr', async () => {
     await Promise.all([
       removeIfExists(payments, '123free', '123opensource', '123stripe', '123team', '123business'),
       removeIfExists(repositories, '42', ' 42b', '43', '44', '44b', '45', '46',
-      'repoId:branch:1234abcd', '47', '48', '49', 'repoId:branch:monorepo1', 'repoId:branch:monorepo2', 'repoId:branch:closes-issues')
+        'repoId:branch:1234abcd', '47', '48', '49', 'repoId:branch:monorepo1', 'repoId:branch:monorepo2', 'repoId:branch:closes-issues')
     ])
   })
 

--- a/test/jobs/create-version-branch.js
+++ b/test/jobs/create-version-branch.js
@@ -51,8 +51,9 @@ describe('create version branch', () => {
     await Promise.all([
       removeIfExists(installations, '123', '124', '124gke', '125', '126', '127', '2323'),
       removeIfExists(payments, '124', '125'),
-      removeIfExists(repositories, '41', '42', '43', '44', '45', '46', '47', '48', '49', '50', '51', '86', 'too-many-packages'),
-      removeIfExists(repositories, '41:branch:1234abcd', '41:pr:321', '42:branch:1234abcd', '43:branch:1234abcd', '50:branch:1234abcd', '50:pr:321', '86:branch:1234abcd', '1:branch:2222abcd', '1:pr:3210')
+      removeIfExists(repositories, '1', '41', '42', '43', '44', '45', '46', '47', '48', '49', '50', '51', '86', 'too-many-packages'),
+      removeIfExists(repositories, '41:branch:1234abcd', '42:branch:1234abcd', '43:branch:1234abcd', '50:branch:1234abcd', '86:branch:1234abcd', '1:branch:2222abcd',
+        '41:pr:321', '50:pr:321', '1:pr:3210')
     ])
   })
 

--- a/test/jobs/github-event/installation/created.js
+++ b/test/jobs/github-event/installation/created.js
@@ -5,6 +5,16 @@ const dbs = require('../../../../lib/dbs')
 const removeIfExists = require('../../../helpers/remove-if-exists')
 const createInstallation = require('../../../../jobs/github-event/installation/created')
 
+afterAll(async () => {
+  const { installations, repositories } = await dbs()
+
+  await Promise.all([
+    removeIfExists(installations, '2'),
+    removeIfExists(repositories, '123', '234')
+  ])
+  require('../../../../lib/statsd').close()
+})
+
 test('github-event installation created', async () => {
   const { installations, repositories } = await dbs()
   nock('https://api.github.com')
@@ -74,14 +84,4 @@ test('github-event installation created', async () => {
   expect(doc.installation).toBe(1)
   expect(doc.login).toBe('bar')
   expect(doc.type).toBe('baz')
-})
-
-afterAll(async () => {
-  const { installations, repositories } = await dbs()
-
-  await Promise.all([
-    removeIfExists(installations, '2'),
-    removeIfExists(repositories, '123', '234')
-  ])
-  require('../../../../lib/statsd').close()
 })

--- a/test/jobs/github-event/issues/closed.js
+++ b/test/jobs/github-event/issues/closed.js
@@ -2,6 +2,11 @@ const dbs = require('../../../../lib/dbs')
 const removeIfExists = require('../../../helpers/remove-if-exists')
 const closeIssue = require('../../../../jobs/github-event/issues/closed')
 
+afterAll(async () => {
+  const { repositories } = await dbs()
+  await removeIfExists(repositories, '42:issue:666')
+})
+
 test('github-event issues closed', async () => {
   const { repositories } = await dbs()
 
@@ -30,9 +35,4 @@ test('github-event issues closed', async () => {
 
   expect(issue.state).toEqual('closed')
   expect(issue.updatedAt).toBeTruthy()
-})
-
-afterAll(async () => {
-  const { repositories } = await dbs()
-  await removeIfExists(repositories, '42:issue:666')
 })

--- a/test/jobs/github-event/marketplace_purchase/cancelled.js
+++ b/test/jobs/github-event/marketplace_purchase/cancelled.js
@@ -3,6 +3,11 @@ const removeIfExists = require('../../../helpers/remove-if-exists.js')
 const cancelPurchase = require('../../../../jobs/github-event/marketplace_purchase/cancelled')
 
 describe('marketplace canceled', async () => {
+  afterAll(async () => {
+    const { payments } = await dbs()
+    await removeIfExists(payments, '444')
+  })
+
   test('change entry in payments database to `free`', async () => {
     const { payments } = await dbs()
     await payments.put({
@@ -37,10 +42,5 @@ describe('marketplace canceled', async () => {
 
     const payment = await payments.get('444')
     expect(payment.plan).toEqual('free')
-  })
-
-  afterAll(async () => {
-    const { payments } = await dbs()
-    await removeIfExists(payments, '444')
   })
 })

--- a/test/jobs/github-event/marketplace_purchase/purchased.js
+++ b/test/jobs/github-event/marketplace_purchase/purchased.js
@@ -3,6 +3,11 @@ const removeIfExists = require('../../../helpers/remove-if-exists.js')
 const purchasePurchase = require('../../../../jobs/github-event/marketplace_purchase/purchased')
 
 describe('marketplace purchased', async () => {
+  afterAll(async () => {
+    const { payments } = await dbs()
+    await removeIfExists(payments, '444', '445', '446', '447', '448')
+  })
+
   test('create entry in payments database', async () => {
     const { payments } = await dbs()
 
@@ -195,10 +200,5 @@ describe('marketplace purchased', async () => {
 
     const payment = await payments.get('448')
     expect(payment.plan).toEqual('opensource')
-  })
-
-  afterAll(async () => {
-    const { payments } = await dbs()
-    await removeIfExists(payments, '444', '445', '446', '447', '448')
   })
 })

--- a/test/jobs/github-event/pull_request/closed.js
+++ b/test/jobs/github-event/pull_request/closed.js
@@ -62,6 +62,14 @@ describe('github-event pull_request closed', async () => {
     ])
   })
 
+  afterAll(async () => {
+    const { repositories, payments } = await dbs()
+    await Promise.all([
+      removeIfExists(repositories, '42:pr:666', '43:pr:777', '44:pr:888', '42', '43', '44'),
+      removeIfExists(payments, '1')
+    ])
+  })
+
   test('initial pr merged', async () => {
     const { repositories } = await dbs()
 
@@ -189,13 +197,5 @@ describe('github-event pull_request closed', async () => {
     })
     githubMock.done()
     expect(newJob).toBeFalsy()
-  })
-
-  afterAll(async () => {
-    const { repositories, payments } = await dbs()
-    await Promise.all([
-      removeIfExists(repositories, '42:pr:666', '43:pr:777', '44:pr:888', '42', '43', '44'),
-      removeIfExists(payments, '1')
-    ])
   })
 })

--- a/test/jobs/github-event/pull_request/opened.js
+++ b/test/jobs/github-event/pull_request/opened.js
@@ -55,6 +55,15 @@ describe('github-event pull_request opened', async () => {
     })
   })
 
+  afterAll(async () => {
+    const { repositories } = await dbs()
+    await Promise.all([
+      removeIfExists(repositories, '40', '41'),
+      removeIfExists(repositories, '40:pr:666', '40:pr:667', '40:pr:668', '40:pr:669', '40:pr:670'),
+      removeIfExists(repositories, '41:pr:666', '41:pr:667', '41:pr:668', '41:pr:669', '41:pr:670')
+    ])
+  })
+
   test('initial pr opened by user', async () => {
     const { repositories } = await dbs()
     const prOpened = requireFresh(pathToWorker)
@@ -202,14 +211,5 @@ describe('github-event pull_request opened', async () => {
       // prdoc was not created
       expect(e.status).toBe(404)
     }
-  })
-
-  afterAll(async () => {
-    const { repositories } = await dbs()
-    await Promise.all([
-      removeIfExists(repositories, '40', '41'),
-      removeIfExists(repositories, '40:pr:666', '40:pr:667', '40:pr:668', '40:pr:669', '40:pr:670'),
-      removeIfExists(repositories, '41:pr:666', '41:pr:667', '41:pr:668', '41:pr:669', '41:pr:670')
-    ])
   })
 })

--- a/test/jobs/github-event/push.js
+++ b/test/jobs/github-event/push.js
@@ -35,6 +35,14 @@ describe('github-event push', async () => {
     })
   })
 
+  afterAll(async () => {
+    const { repositories, payments } = await dbs()
+
+    await removeIfExists(repositories, '333', '444', '444A', '445', '445A', '446', '447', '448', '555',
+      '444:branch:1234abcd', '444:branch:1234abce', '444A:branch:1234abcd', '444A:branch:1234abce')
+    await removeIfExists(payments, '123')
+  })
+
   test('package.json added/modified for a not enabled repo (333)', async () => {
     const { repositories } = await dbs()
 
@@ -900,6 +908,25 @@ describe('github-event push: monorepo', () => {
   beforeEach(() => {
     jest.resetModules()
     nock.cleanAll()
+  })
+
+  afterAll(async () => {
+    const { repositories } = await dbs()
+
+    await removeIfExists(repositories, '666', '3462',
+      '777', '777:branch:1234abcd', '777:branch:1234abce', '777:branch:1234abcf', '777:branch:1234abcg',
+      '777A', '777A:branch:1234abca', '777A:branch:1234abcb', '777A:branch:1234abcc',
+      '888', '888:branch:1234abca', '888:branch:1234abcb',
+      '999', '999:branch:1234abca', '999:branch:1234abcb',
+      '1111',
+      '1112', '1112:branch:1234abca', '1112:branch:1234abcb',
+      '1113', '1113:branch:1234abca', '1113:branch:1234abcb',
+      '1114', '1114:branch:1234abca', '1114:branch:1234abcb',
+      '1115', '1115:branch:1234abca', '1115:branch:1234abcb',
+      '1116', '1116:branch:1234abca', '1116:branch:1234abcb',
+      '1117', '1117:branch:1234abca',
+      '1118', '1118:branch:1234abca',
+      'mga1', 'mga2', 'mga3', 'mgm1', 'mgm2', 'mgm3', 'mgm4', 'mgm5', 'too-many-packages')
   })
 
   test('monorepo: create no pull request for too many package.jsons', async () => {
@@ -4453,26 +4480,6 @@ describe('github-event push: monorepo', () => {
     expect(repo.openInitialPRWhenConfigFileFixed).toBeFalsy()
     expect(repo.greenkeeper).toMatchObject(configFileContent)
   })
-})
-
-afterAll(async () => {
-  const { repositories, payments } = await dbs()
-
-  await removeIfExists(repositories, '444', '444A', '445', '445A', '446', '447', '448', '444:branch:1234abcd', '444:branch:1234abce', '444A:branch:1234abcd', '444A:branch:1234abce', '555', '666',
-    '777', '777:branch:1234abcd', '777:branch:1234abce', '777:branch:1234abcf', '777:branch:1234abcg',
-    '777A', '777A:branch:1234abca', '777A:branch:1234abcb', '777A:branch:1234abcc',
-    '888', '888:branch:1234abca', '888:branch:1234abcb',
-    '999', '999:branch:1234abca', '999:branch:1234abcb',
-    '1111',
-    '1112', '1112:branch:1234abca', '1112:branch:1234abcb',
-    '1113', '1113:branch:1234abca', '1113:branch:1234abcb',
-    '1114', '1114:branch:1234abca', '1114:branch:1234abcb',
-    '1115', '1115:branch:1234abca', '1115:branch:1234abcb',
-    '1116', '1116:branch:1234abca', '1116:branch:1234abcb',
-    '1117', '1117:branch:1234abca',
-    '1118', '1118:branch:1234abca',
-    'mga1', 'mga2', 'mga3', 'mgm1', 'mgm2', 'mgm3', 'mgm4', 'mgm5', 'too-many-packages')
-  await removeIfExists(payments, '123')
 })
 
 function encodePkg (pkg) {

--- a/test/jobs/github-event/status.js
+++ b/test/jobs/github-event/status.js
@@ -20,6 +20,15 @@ describe('github-event status', async () => {
     jest.resetModules()
   })
 
+  afterAll(async () => {
+    const { repositories, installations } = await dbs()
+    await Promise.all([
+      removeIfExists(installations, '10'),
+      removeIfExists(repositories, '42:branch:deadbeef', '43:branch:deadbeef', '44:branch:deadbeef', '44:pr:1234',
+        'subgroup1:branch:abcdf1234', 'subgroup2:branch:plantsarethebest11', 'subgroup2:pr:1234')
+    ])
+  })
+
   test('initial pr', async () => {
     const { repositories } = await dbs()
     expect.assertions(6)
@@ -300,15 +309,5 @@ describe('github-event status', async () => {
       }
     })
     expect(newJob).toBeFalsy()
-  })
-
-  afterAll(async () => {
-    const { repositories, installations } = await dbs()
-    await Promise.all([
-      removeIfExists(installations, '10'),
-      removeIfExists(repositories, '42:branch:deadbeef', '43:branch:deadbeef',
-        '44:branch:deadbeef', '44:pr:1234', 'subgroup1:branch:abcdf1234',
-        'subgroup2:branch:plantsarethebest11', 'subgroup2:pr:1234')
-    ])
   })
 })

--- a/test/jobs/initial-timeout-pr.js
+++ b/test/jobs/initial-timeout-pr.js
@@ -18,6 +18,14 @@ describe('initial-timeout-pr', async () => {
     })
   })
 
+  afterAll(async () => {
+    const { repositories, installations } = await dbs()
+    await Promise.all([
+      removeIfExists(installations, '10101', '1338'),
+      removeIfExists(repositories, '666', '666:pr:11', '666:issue:10')
+    ])
+  })
+
   test('create', async () => {
     const githubMock = nock('https://api.github.com')
       .post('/installations/37/access_tokens')
@@ -85,12 +93,4 @@ describe('initial-timeout-pr', async () => {
       expect(true).toBeTruthy()
     }
   })
-})
-
-afterAll(async () => {
-  const { repositories, installations } = await dbs()
-  await Promise.all([
-    removeIfExists(installations, '10101', '1338'),
-    removeIfExists(repositories, '666', '666:pr:11', '666:issue:10')
-  ])
 })

--- a/test/jobs/invalid-config-file.js
+++ b/test/jobs/invalid-config-file.js
@@ -23,6 +23,16 @@ describe('invalid-config-file', async () => {
     })
   })
 
+  afterAll(async () => {
+    const { repositories, installations } = await dbs()
+    await Promise.all([
+      removeIfExists(installations, '2020', '2121'),
+      removeIfExists(repositories, 'invalid-config1', 'invalid-config1:issue:10',
+        'invalid-config2', 'invalid-config2:issue:10',
+        'invalid-config3', 'invalid-config3:issue:10', 'invalid-config3:issue:11', 'invalid-config4:issue:11')
+    ])
+  })
+
   test('create new issue', async () => {
     expect.assertions(12)
     const githubMock = nock('https://api.github.com')
@@ -218,14 +228,4 @@ describe('invalid-config-file', async () => {
     expect(issue.repositoryId).toBe('invalid-config4')
     githubMock.done()
   })
-})
-
-afterAll(async () => {
-  const { repositories, installations } = await dbs()
-  await Promise.all([
-    removeIfExists(installations, '2020', '2121'),
-    removeIfExists(repositories, 'invalid-config1', 'invalid-config1:issue:10',
-      'invalid-config2', 'invalid-config2:issue:10',
-      'invalid-config3', 'invalid-config3:issue:10', 'invalid-config3:issue:11', 'invalid-config4:issue:11')
-  ])
 })

--- a/test/jobs/stripe-event.js
+++ b/test/jobs/stripe-event.js
@@ -6,6 +6,11 @@ const removeIfExists = require('../helpers/remove-if-exists')
 nock.disableNetConnect()
 nock.enableNetConnect('localhost')
 
+afterAll(async () => {
+  const { payments } = await dbs()
+  await removeIfExists(payments, '1')
+})
+
 test('enqueue email job when recieving stripe cancel event', async () => {
   const { payments } = await dbs()
   const stripeEvent = require('../../jobs/stripe-event')
@@ -35,9 +40,4 @@ test('enqueue email job when recieving stripe cancel event', async () => {
   expect(job.data.name).toEqual('send-stripe-cancel-survey')
   expect(job.data.stripeSubscriptionId).toEqual('stripe_test_SubscriptionId')
   expect(job.data.accountId).toEqual('1')
-})
-
-afterAll(async () => {
-  const { payments } = await dbs()
-  await removeIfExists(payments, '1')
 })


### PR DESCRIPTION
We want a better overview of our setup and therefore place all the test setup (the Jest globals `beforeEach()`, `beforeAll()`, `afterEach()` and `afterAll()`) together in one place on top of each testfile.