### PR TITLE
Make nock token requests optional

### DIFF
--- a/test/jobs/github-event/installation/created.js
+++ b/test/jobs/github-event/installation/created.js
@@ -10,10 +10,12 @@ test('github-event installation created', async () => {
 
   nock('https://api.github.com')
     .post('/installations/1/access_tokens')
+    .optionally()
     .reply(200, {
       token: 'secret'
     })
     .get('/rate_limit')
+    .optionally()
     .reply(200, {})
     .get('/installation/repositories?per_page=100')
     .reply('200', {

--- a/test/jobs/github-event/marketplace_purchase/purchased.js
+++ b/test/jobs/github-event/marketplace_purchase/purchased.js
@@ -1,11 +1,6 @@
-const nock = require('nock')
-
 const dbs = require('../../../../lib/dbs')
 const removeIfExists = require('../../../helpers/remove-if-exists.js')
 const purchasePurchase = require('../../../../jobs/github-event/marketplace_purchase/purchased')
-
-nock.disableNetConnect()
-nock.enableNetConnect('localhost')
 
 describe('marketplace purchased', async () => {
   beforeAll(() => {

--- a/test/jobs/github-event/push.js
+++ b/test/jobs/github-event/push.js
@@ -40,10 +40,12 @@ describe('github-event push', async () => {
 
     nock('https://api.github.com')
       .post('/installations/37/access_tokens')
+      .optionally()
       .reply(200, {
         token: 'secret'
       })
       .get('/rate_limit')
+      .optionally()
       .reply(200, {})
       .get('/repos/finn/disabled/contents/package.json')
       .reply(200, {
@@ -154,10 +156,12 @@ describe('github-event push', async () => {
 
     nock('https://api.github.com')
       .post('/installations/11/access_tokens')
+      .optionally()
       .reply(200, {
         token: 'secret'
       })
       .get('/rate_limit')
+      .optionally()
       .reply(200, {})
       .get('/repos/hans/monorepo/contents/greenkeeper.json')
       .reply(200, {
@@ -251,10 +255,12 @@ describe('github-event push', async () => {
 
     nock('https://api.github.com')
       .post('/installations/11/access_tokens')
+      .optionally()
       .reply(200, {
         token: 'secret'
       })
       .get('/rate_limit')
+      .optionally()
       .reply(200, {})
       .get('/repos/hans/monorepo/contents/greenkeeper.json')
       .reply(200, {
@@ -370,10 +376,12 @@ describe('github-event push', async () => {
 
     nock('https://api.github.com')
       .post('/installations/38/access_tokens')
+      .optionally()
       .reply(200, {
         token: 'secret'
       })
       .get('/rate_limit')
+      .optionally()
       .reply(200, {})
       .get('/repos/finn/test/contents/package.json')
       .reply(200, {
@@ -482,10 +490,12 @@ describe('github-event push', async () => {
 
     nock('https://api.github.com')
       .post('/installations/39/access_tokens')
+      .optionally()
       .reply(200, {
         token: 'secret'
       })
       .get('/rate_limit')
+      .optionally()
       .reply(200, {})
       .get('/repos/finn/test/contents/package.json')
       .reply(200, {
@@ -561,10 +571,12 @@ describe('github-event push', async () => {
 
     nock('https://api.github.com')
       .post('/installations/40/access_tokens')
+      .optionally()
       .reply(200, {
         token: 'secret'
       })
       .get('/rate_limit')
+      .optionally()
       .reply(200, {})
       .get('/repos/finn/test/contents/package.json')
       .reply(200, {
@@ -886,10 +898,12 @@ describe('github-event push: monorepo', () => {
 
     nock('https://api.github.com')
       .post('/installations/11/access_tokens')
+      .optionally()
       .reply(200, {
         token: 'secret'
       })
       .get('/rate_limit')
+      .optionally()
       .reply(200, {})
       .get('/repos/hans/monorepo/contents/greenkeeper.json')
       .reply(200, {
@@ -1036,10 +1050,12 @@ describe('github-event push: monorepo', () => {
 
     nock('https://api.github.com')
       .post('/installations/11/access_tokens')
+      .optionally()
       .reply(200, {
         token: 'secret'
       })
       .get('/rate_limit')
+      .optionally()
       .reply(200, {})
       .get('/repos/hans/monorepo/contents/greenkeeper.json')
       .reply(200, {
@@ -1223,10 +1239,12 @@ describe('github-event push: monorepo', () => {
 
     nock('https://api.github.com')
       .post('/installations/11/access_tokens')
+      .optionally()
       .reply(200, {
         token: 'secret'
       })
       .get('/rate_limit')
+      .optionally()
       .reply(200, {})
       .get('/repos/hans/monorepo/contents/greenkeeper.json')
       .reply(200, {
@@ -1423,10 +1441,12 @@ describe('github-event push: monorepo', () => {
 
     nock('https://api.github.com')
       .post('/installations/11/access_tokens')
+      .optionally()
       .reply(200, {
         token: 'secret'
       })
       .get('/rate_limit')
+      .optionally()
       .reply(200, {})
       .get('/repos/hans/monorepo/contents/greenkeeper.json')
       .reply(200, {
@@ -1637,10 +1657,12 @@ describe('github-event push: monorepo', () => {
 
     nock('https://api.github.com')
       .post('/installations/11/access_tokens')
+      .optionally()
       .reply(200, {
         token: 'secret'
       })
       .get('/rate_limit')
+      .optionally()
       .reply(200, {})
       .get('/repos/hans/monorepo/contents/greenkeeper.json')
       .reply(200, {
@@ -1828,10 +1850,12 @@ describe('github-event push: monorepo', () => {
 
     nock('https://api.github.com')
       .post('/installations/11/access_tokens')
+      .optionally()
       .reply(200, {
         token: 'secret'
       })
       .get('/rate_limit')
+      .optionally()
       .reply(200, {})
       .get('/repos/hans/monorepo/contents/greenkeeper.json')
       .reply(200, {
@@ -1991,10 +2015,12 @@ describe('github-event push: monorepo', () => {
 
     nock('https://api.github.com')
       .post('/installations/11/access_tokens')
+      .optionally()
       .reply(200, {
         token: 'secret'
       })
       .get('/rate_limit')
+      .optionally()
       .reply(200, {})
       .get('/repos/hans/monorepo/contents/greenkeeper.json')
       .reply(200, {
@@ -2187,10 +2213,12 @@ describe('github-event push: monorepo', () => {
 
     nock('https://api.github.com')
       .post('/installations/11/access_tokens')
+      .optionally()
       .reply(200, {
         token: 'secret'
       })
       .get('/rate_limit')
+      .optionally()
       .reply(200, {})
       .get('/repos/hans/monorepo/contents/greenkeeper.json')
       .reply(200, {
@@ -2379,10 +2407,12 @@ describe('github-event push: monorepo', () => {
 
     nock('https://api.github.com')
       .post('/installations/11/access_tokens')
+      .optionally()
       .reply(200, {
         token: 'secret'
       })
       .get('/rate_limit')
+      .optionally()
       .reply(200, {})
       .get('/repos/hans/monorepo/contents/greenkeeper.json')
       .reply(200, {
@@ -2570,10 +2600,12 @@ describe('github-event push: monorepo', () => {
 
     nock('https://api.github.com')
       .post('/installations/11/access_tokens')
+      .optionally()
       .reply(200, {
         token: 'secret'
       })
       .get('/rate_limit')
+      .optionally()
       .reply(200, {})
       .get('/repos/hans/monorepo/contents/greenkeeper.json')
       .reply(200, {
@@ -2760,10 +2792,12 @@ describe('github-event push: monorepo', () => {
 
     nock('https://api.github.com')
       .post('/installations/11/access_tokens')
+      .optionally()
       .reply(200, {
         token: 'secret'
       })
       .get('/rate_limit')
+      .optionally()
       .reply(200, {})
       .get('/repos/hans/monorepo/contents/greenkeeper.json')
       .reply(200, {
@@ -2958,10 +2992,12 @@ describe('github-event push: monorepo', () => {
 
     nock('https://api.github.com')
       .post('/installations/11/access_tokens')
+      .optionally()
       .reply(200, {
         token: 'secret'
       })
       .get('/rate_limit')
+      .optionally()
       .reply(200, {})
       .get('/repos/hans/monorepo/contents/greenkeeper.json')
       .reply(200, {
@@ -3133,10 +3169,12 @@ describe('github-event push: monorepo', () => {
 
     nock('https://api.github.com')
       .post('/installations/11/access_tokens')
+      .optionally()
       .reply(200, {
         token: 'secret'
       })
       .get('/rate_limit')
+      .optionally()
       .reply(200, {})
       .get('/repos/hans/monorepo/contents/greenkeeper.json')
       .reply(404)
@@ -3253,10 +3291,12 @@ describe('github-event push: monorepo', () => {
 
     nock('https://api.github.com')
       .post('/installations/11/access_tokens')
+      .optionally()
       .reply(200, {
         token: 'secret'
       })
       .get('/rate_limit')
+      .optionally()
       .reply(200, {})
       .get('/repos/hans/monorepo/contents/greenkeeper.json')
       .reply(404)
@@ -3364,10 +3404,12 @@ describe('github-event push: monorepo', () => {
 
     nock('https://api.github.com')
       .post('/installations/11/access_tokens')
+      .optionally()
       .reply(200, {
         token: 'secret'
       })
       .get('/rate_limit')
+      .optionally()
       .reply(200, {})
       .get('/repos/hans/monorepo/contents/package.json')
       .reply(200, {
@@ -3471,10 +3513,12 @@ describe('github-event push: monorepo', () => {
 
     nock('https://api.github.com')
       .post('/installations/11/access_tokens')
+      .optionally()
       .reply(200, {
         token: 'secret'
       })
       .get('/rate_limit')
+      .optionally()
       .reply(200, {})
       .get('/repos/hans/monorepo/contents/package.json')
       .reply(200, {
@@ -3581,10 +3625,12 @@ describe('github-event push: monorepo', () => {
 
     nock('https://api.github.com')
       .post('/installations/11/access_tokens')
+      .optionally()
       .reply(200, {
         token: 'secret'
       })
       .get('/rate_limit')
+      .optionally()
       .reply(200, {})
       .get('/repos/hans/monorepo/contents/package.json')
       .reply(200, {
@@ -3696,10 +3742,12 @@ describe('github-event push: monorepo', () => {
 
     nock('https://api.github.com')
       .post('/installations/11/access_tokens')
+      .optionally()
       .reply(200, {
         token: 'secret'
       })
       .get('/rate_limit')
+      .optionally()
       .reply(200, {})
       .get('/repos/hans/monorepo/contents/package.json')
       .reply(200, {
@@ -3812,10 +3860,12 @@ describe('github-event push: monorepo', () => {
 
     nock('https://api.github.com')
       .post('/installations/11/access_tokens')
+      .optionally()
       .reply(200, {
         token: 'secret'
       })
       .get('/rate_limit')
+      .optionally()
       .reply(200, {})
       .get('/repos/hans/monorepo/contents/package.json')
       .reply(200, {
@@ -3931,10 +3981,12 @@ describe('github-event push: monorepo', () => {
 
     nock('https://api.github.com')
       .post('/installations/11/access_tokens')
+      .optionally()
       .reply(200, {
         token: 'secret'
       })
       .get('/rate_limit')
+      .optionally()
       .reply(200, {})
       .get('/repos/hans/monorepo/contents/package.json')
       .reply(200, {

--- a/test/lib/get-diff-commits.js
+++ b/test/lib/get-diff-commits.js
@@ -7,10 +7,12 @@ test('get-diff-commits', async () => {
 
   nock('https://api.github.com')
     .post('/installations/123/access_tokens')
+    .optionally()
     .reply(200, {
       token: 'secret'
     })
     .get('/rate_limit')
+    .optionally()
     .reply(200, {})
     .get('/repos/finnp/test/compare/dead...beef')
     .reply(200, () => {

--- a/test/lib/get-files.js
+++ b/test/lib/get-files.js
@@ -10,10 +10,12 @@ test('getFiles: with no fileList provided', async () => {
 
   nock('https://api.github.com')
     .post('/installations/123/access_tokens')
+    .optionally()
     .reply(200, {
       token: 'secret'
     })
     .get('/rate_limit')
+    .optionally()
     .reply(200, {})
 
   const files = await getFiles('123', 'owner/repo')
@@ -27,10 +29,12 @@ test('getFiles: 2 package.json files', async () => {
 
   nock('https://api.github.com')
     .post('/installations/123/access_tokens')
+    .optionally()
     .reply(200, {
       token: 'secret'
     })
     .get('/rate_limit')
+    .optionally()
     .reply(200, {})
     .get('/repos/owner/repo/contents/package.json')
     .reply(200, {
@@ -76,10 +80,12 @@ test('getFiles: 2 package.json files but one is not found on github', async () =
 
   nock('https://api.github.com')
     .post('/installations/123/access_tokens')
+    .optionally()
     .reply(200, {
       token: 'secret'
     })
     .get('/rate_limit')
+    .optionally()
     .reply(200, {})
     .get('/repos/owner/repo/contents/backend/package.json')
     .reply(200, {
@@ -185,10 +191,12 @@ test('getGreenkeeperConfigFile', async () => {
 
   nock('https://api.github.com')
     .post('/installations/123/access_tokens')
+    .optionally()
     .reply(200, {
       token: 'secret'
     })
     .get('/rate_limit')
+    .optionally()
     .reply(200, {})
     .get('/repos/owner/repo/contents/greenkeeper.json')
     .reply(200, {
@@ -209,10 +217,12 @@ test('getGreenkeeperConfigFile: when no config file is present', async () => {
 
   nock('https://api.github.com')
     .post('/installations/123/access_tokens')
+    .optionally()
     .reply(200, {
       token: 'secret'
     })
     .get('/rate_limit')
+    .optionally()
     .reply(200, {})
     .get('/repos/owner/repo/contents/greenkeeper.json')
     .reply(404)
@@ -264,10 +274,12 @@ test('discoverPackageFiles: regular repo', async () => {
 
   nock('https://api.github.com')
     .post('/installations/123/access_tokens')
+    .optionally()
     .reply(200, {
       token: 'secret'
     })
     .get('/rate_limit')
+    .optionally()
     .reply(200, {})
     .get('/repos/owner/repo/git/trees/master?recursive=true')
     .reply(200, {
@@ -307,10 +319,12 @@ test('discoverPackageFiles: monorepo', async () => {
 
   nock('https://api.github.com')
     .post('/installations/123/access_tokens')
+    .optionally()
     .reply(200, {
       token: 'secret'
     })
     .get('/rate_limit')
+    .optionally()
     .reply(200, {})
     .get('/repos/owner/repo/git/trees/master?recursive=true')
     .reply(200, {
@@ -385,10 +399,12 @@ test('discoverPackageFilePaths: regular repo', async () => {
 
   nock('https://api.github.com')
     .post('/installations/123/access_tokens')
+    .optionally()
     .reply(200, {
       token: 'secret'
     })
     .get('/rate_limit')
+    .optionally()
     .reply(200, {})
     .get('/repos/owner/repo/git/trees/master?recursive=true')
     .reply(200, {
@@ -422,10 +438,12 @@ test('discoverPackageFilePaths: monorepo', async () => {
 
   nock('https://api.github.com')
     .post('/installations/123/access_tokens')
+    .optionally()
     .reply(200, {
       token: 'secret'
     })
     .get('/rate_limit')
+    .optionally()
     .reply(200, {})
     .get('/repos/owner/repo/git/trees/master?recursive=true')
     .reply(200, {

--- a/test/lib/get-release.js
+++ b/test/lib/get-release.js
@@ -31,10 +31,12 @@ test('get-release from tag with v prefix', async () => {
 test('get-release from tag with version as name', async () => {
   nock('https://api.github.com')
     .post('/installations/123/access_tokens')
+    .optionally()
     .reply(200, {
       token: 'secret'
     })
     .get('/rate_limit')
+    .optionally()
     .reply(200, {})
     .get('/repos/finnp/test/releases/tags/v1.33.7')
     .reply(404)
@@ -57,10 +59,12 @@ test('get-release from tag with version as name', async () => {
 test('get-release from tag at sha', async () => {
   nock('https://api.github.com')
     .post('/installations/123/access_tokens')
+    .optionally()
     .reply(200, {
       token: 'secret'
     })
     .get('/rate_limit')
+    .optionally()
     .reply(200, {})
     .get('/repos/finnp/test/releases/tags/v1.33.7')
     .reply(404)

--- a/test/lib/handle-branch-status.js
+++ b/test/lib/handle-branch-status.js
@@ -164,10 +164,12 @@ describe('handle-branch-status', async () => {
 
     nock('https://api.github.com')
       .post('/installations/123/access_tokens')
+      .optionally()
       .reply(200, {
         token: 'secret'
       })
       .get('/rate_limit')
+      .optionally()
       .reply(200, {})
       .post('/repos/club/mate/issues/5/comments')
       .reply(201, () => {

--- a/test/lib/repository-docs.js
+++ b/test/lib/repository-docs.js
@@ -44,10 +44,12 @@ test('updateRepoDoc with package.json', async () => {
 test('get invalid package.json', async () => {
   nock('https://api.github.com')
     .post('/installations/123/access_tokens')
+    .optionally()
     .reply(200, {
       token: 'secret'
     })
     .get('/rate_limit')
+    .optionally()
     .reply(200, {})
     .get('/repos/owner/repo/contents/package.json')
     .reply(200, {
@@ -96,10 +98,12 @@ test('updateRepoDoc with greenkeeper.json present', async () => {
 
   nock('https://api.github.com')
     .post('/installations/123/access_tokens')
+    .optionally()
     .reply(200, {
       token: 'secret'
     })
     .get('/rate_limit')
+    .optionally()
     .reply(200, {})
     .get('/repos/owner/repo/contents/greenkeeper.json')
     .reply(200, {

--- a/test/utils/initial-branch-utils.js
+++ b/test/utils/initial-branch-utils.js
@@ -1,11 +1,6 @@
-const nock = require('nock')
-
 const dbs = require('../../lib/dbs')
 const removeIfExists = require('../helpers/remove-if-exists')
 const { cleanCache } = require('../helpers/module-cache-helpers')
-
-nock.disableNetConnect()
-nock.enableNetConnect('localhost')
 
 describe('create initial branch', () => {
   beforeEach(() => {


### PR DESCRIPTION
- test: make nock token-requests optional because of caching that we cannot override from test setup
- remove nock imports where we don't use it