### PR TITLE
Fix/handle invalid config in initial branch

### DIFF
--- a/content/initial-pr.js
+++ b/content/initial-pr.js
@@ -197,7 +197,7 @@ const greenkeeperConfigInfoMessage = (info) => {
 }
 
 const closeMessages = (issueNumbers) => {
-  if (issueNumbers && issueNumbers.length === 0) { return }
+  if (!issueNumbers || issueNumbers.length === 0) { return }
   return '\nCloses: #' + issueNumbers.join(', #')
 }
 

--- a/content/initial-pr.js
+++ b/content/initial-pr.js
@@ -196,7 +196,12 @@ const greenkeeperConfigInfoMessage = (info) => {
   return message
 }
 
-function prBody ({ghRepo, success, secret, installationId, newBranch, badgeUrl, travisModified, enabled, depsUpdated, accountTokenUrl, files, greenkeeperConfigInfo, groupName}) {
+const closeMessages = (issueNumbers) => {
+  if (issueNumbers && issueNumbers.length === 0) { return }
+  return '\nCloses: #' + issueNumbers.join(', #')
+}
+
+function prBody ({ghRepo, success, secret, installationId, newBranch, badgeUrl, travisModified, enabled, depsUpdated, accountTokenUrl, files, greenkeeperConfigInfo, groupName, closes}) {
   return md`
 ${!groupName && `Let’s get started with automated dependency management for ${ghRepo.name} :muscle:`}
 
@@ -223,6 +228,7 @@ ${
     faqText()
   ]).map(text => `<details>${text}</details>`)
 }
+${closeMessages(closes)}
 
 ---
 

--- a/content/invalid-config-issue.js
+++ b/content/invalid-config-issue.js
@@ -1,17 +1,17 @@
 const md = require('./template')
 
-module.exports = (messages) => {
+module.exports = (messages, isBlockingInitialPR) => {
   let messageList = messages.map((message, index) => {
     return `${index + 1}. ${message}`
   }).join('\n')
 
-  return md`We have detected a problem with your Greenkeeper config file 🚨
+  return md`We have detected a problem with your Greenkeeper config file ${isBlockingInitialPR ? 'which is preventing Greenkeeper from opening its initial pull request' : ''} 🚨
 
 Greenkeeper currently can’t work with your \`greenkeeper.json\` config file because it is invalid. We found the following issue${messages.length === 1 ? '' : 's'}:
 
 ${messageList}
 
-Please correct ${messages.length === 1 ? 'this' : 'these'} and commit the fix to your default branch (usually master). Greenkeeper will pick up your changes and try again. If in doubt, please consult the [config documentation](https://greenkeeper.io/docs.html#config).
+Please correct ${messages.length === 1 ? 'this' : 'these'} and commit the fix to your default branch (usually master)${isBlockingInitialPR ? ' so Greenkeeper can run on this repository' : ''}. Greenkeeper will pick up your changes and try again. If in doubt, please consult the [config documentation](https://greenkeeper.io/docs.html#config).
 
 Here’s an example of a valid \`greenkeeper.json\`:
 

--- a/jobs/create-initial-branch.js
+++ b/jobs/create-initial-branch.js
@@ -23,7 +23,7 @@ const upsert = require('../lib/upsert')
 const { invalidConfigFile } = require('../lib/invalid-config-file')
 const { getUpdatedDependenciesForFiles } = require('../utils/initial-branch-utils')
 
-module.exports = async function ({ repositoryId }) {
+module.exports = async function ({ repositoryId, closes = [] }) {
   const { installations, repositories } = await dbs()
   const logs = dbs.getLogsDb()
   const repoDoc = await repositories.get(repositoryId)
@@ -69,7 +69,8 @@ module.exports = async function ({ repositoryId }) {
         repository: repoDoc,
         repositoryId,
         details: [{ formattedMessage: e.message }],
-        log
+        log,
+        isBlockingInitialPR: true
       })
     }
   }
@@ -299,7 +300,10 @@ module.exports = async function ({ repositoryId }) {
     travisModified,
     badgeAdded,
     badgeUrl,
-    greenkeeperConfigInfo
+    greenkeeperConfigInfo,
+    // If there are issues that should be closed by the initial PR message,
+    // put them in the branch doc so we can find them later
+    closes
   })
 
   statsd.increment('initial_branch')

--- a/jobs/create-initial-pr.js
+++ b/jobs/create-initial-pr.js
@@ -38,6 +38,8 @@ module.exports = async function (
     greenkeeperConfigInfo
   } = branchDoc
 
+  const closes = branchDoc.closes || []
+
   let enabled = false
   if (!depsUpdated && !repodoc.private) {
     repodoc = await upsert(repositories, repodoc._id, {
@@ -126,7 +128,8 @@ module.exports = async function (
         enabled,
         accountTokenUrl,
         files,
-        greenkeeperConfigInfo
+        greenkeeperConfigInfo,
+        closes
       }),
       base,
       head

--- a/jobs/github-event/push.js
+++ b/jobs/github-event/push.js
@@ -15,7 +15,7 @@ const {
 } = require('../../lib/branches-to-delete')
 const getConfig = require('../../lib/get-config')
 const { validate } = require('../../lib/validate-greenkeeper-json')
-const { invalidConfigFile } = require('../../lib/invalid-config-file')
+const { invalidConfigFile, getInvalidConfigIssueNumber } = require('../../lib/invalid-config-file')
 
 module.exports = async function (data) {
   const { repositories } = await dbs()
@@ -96,6 +96,8 @@ module.exports = async function (data) {
         log
       })
     }
+    // Config file is valid, so we try to close an open `invalid-config-file` issue
+    const issueToClose = await getInvalidConfigIssueNumber(repositories, repositoryId)
     // If the config is valid and we had previously bailed on an initial branch because it wasn’t,
     // create that now.
     if (repoDoc.openInitialPRWhenConfigFileFixed) {
@@ -106,7 +108,8 @@ module.exports = async function (data) {
         data: {
           name: 'create-initial-branch',
           repositoryId,
-          accountId: repoDoc.accountId
+          accountId: repoDoc.accountId,
+          closes: [issueToClose]
         }
       }
     }

--- a/jobs/github-event/push.js
+++ b/jobs/github-event/push.js
@@ -95,6 +95,20 @@ module.exports = async function (data) {
         log
       })
     }
+    // If the config is valid and we had previously bailed on an initial branch because it wasn’t,
+    // create that now.
+    if (repoDoc.openInitialPRWhenConfigFileFixed) {
+      // reset the flag
+      delete repoDoc.openInitialPRWhenConfigFileFixed
+      await updateDoc(repositories, repository, repoDoc)
+      return {
+        data: {
+          name: 'create-initial-branch',
+          repositoryId,
+          accountId: repoDoc.accountId
+        }
+      }
+    }
   }
 
   // if there are no changes in package.json files or the greenkeeper config

--- a/jobs/invalid-config-file.js
+++ b/jobs/invalid-config-file.js
@@ -7,7 +7,7 @@ const updatedAt = require('../lib/updated-at')
 const invalidConfigBody = require('../content/invalid-config-issue')
 const getConfig = require('../lib/get-config')
 
-module.exports = async function ({ repositoryId, accountId, messages }) {
+module.exports = async function ({ repositoryId, accountId, messages, isBlockingInitialPR }) {
   const { installations, repositories } = await dbs()
   const installation = await installations.get(String(accountId))
   const installationId = installation.installation
@@ -31,7 +31,7 @@ module.exports = async function ({ repositoryId, accountId, messages }) {
     owner,
     repo,
     title: `Invalid Greenkeeper configuration file`,
-    body: invalidConfigBody(messages),
+    body: invalidConfigBody(messages, isBlockingInitialPR),
     labels: [label]
   }))
 

--- a/lib/invalid-config-file.js
+++ b/lib/invalid-config-file.js
@@ -1,0 +1,40 @@
+const updatedAt = require('./updated-at')
+const _ = require('lodash')
+
+async function invalidConfigFile ({repoDoc, config, repositories, repository, repositoryId, details, log}) {
+  log.warn('validation of greenkeeper.json failed', {error: details, greenkeeperJson: repoDoc.greenkeeper})
+  // reset greenkeeper config in repoDoc to the previous working version and start an 'invalid-config-file' job
+  _.set(repoDoc, ['greenkeeper'], config)
+  await updateDoc(repositories, repository, repoDoc)
+  // If the config file is invalid, open an issue with validation errors and don’t do anything else in this file:
+  // - no initial branch should be created (?)
+  // - no initial subgroup branches should (or can be) be created
+  // - no branches need to be deleted (we can’t be sure the changes are valid)
+
+  return {
+    data: {
+      name: 'invalid-config-file',
+      messages: _.map(details, 'formattedMessage'),
+      errors: details,
+      repositoryId,
+      accountId: repoDoc.accountId
+    }
+  }
+}
+
+function updateDoc (repositories, repository, repoDoc) {
+  return repositories.put(
+    updatedAt(
+      Object.assign(repoDoc, {
+        private: repository.private,
+        fullName: repository.full_name,
+        fork: repository.fork,
+        hasIssues: repository.has_issues
+      })
+    )
+  )
+}
+
+module.exports = {
+  invalidConfigFile
+}

--- a/lib/invalid-config-file.js
+++ b/lib/invalid-config-file.js
@@ -1,7 +1,16 @@
 const updatedAt = require('./updated-at')
 const _ = require('lodash')
 
-async function invalidConfigFile ({repoDoc, config, repositories, repository, repositoryId, details, log}) {
+async function getInvalidConfigIssueNumber (repositories, repositoryId) {
+  return _.get(
+    await repositories.query('open_invalid_config_issue', {
+      key: repositoryId,
+      include_docs: true
+    }),
+    'rows[0].number'
+  )
+}
+async function invalidConfigFile ({repoDoc, config, repositories, repository, repositoryId, details, log, isBlockingInitialPR = false}) {
   log.warn('validation of greenkeeper.json failed', {error: details, greenkeeperJson: repoDoc.greenkeeper})
   // reset greenkeeper config in repoDoc to the previous working version and start an 'invalid-config-file' job
   _.set(repoDoc, ['greenkeeper'], config)
@@ -17,7 +26,8 @@ async function invalidConfigFile ({repoDoc, config, repositories, repository, re
       messages: _.map(details, 'formattedMessage'),
       errors: details,
       repositoryId,
-      accountId: repoDoc.accountId
+      accountId: repoDoc.accountId,
+      isBlockingInitialPR
     }
   }
 }
@@ -36,5 +46,6 @@ function updateDoc (repositories, repository, repoDoc) {
 }
 
 module.exports = {
-  invalidConfigFile
+  invalidConfigFile,
+  getInvalidConfigIssueNumber
 }


### PR DESCRIPTION
When we encounter an invalid `greenkeeper.json` while creating an initial branch, we don’t create the branch and instead open the invalid config file issue instead.

On push, when we get a valid `greenkeeper.json` and had previously bailed on an initial PR, we now open that initial PR. 