### PR TITLE
fix(repo-docs): allow initial branch to continue with config file errors

### DIFF
--- a/jobs/create-initial-branch.js
+++ b/jobs/create-initial-branch.js
@@ -60,7 +60,7 @@ module.exports = async function ({ repositoryId, closes = [] }) {
     if (e.name && e.name === 'GKConfigFileParseError') {
       log.warn('create initial branch failed because of an invalid config file')
       // We set a flag that the config was borked. When the next push for the greenkeeper.json comes and it is valid
-      // we can tell by the flag whether we still nee2d to open the initial PR that we didn’t do here.
+      // we can tell by the flag whether we still need to open the initial PR that we didn’t do here.
       repoDoc.openInitialPRWhenConfigFileFixed = true
       return invalidConfigFile({
         repoDoc,

--- a/jobs/create-initial-branch.js
+++ b/jobs/create-initial-branch.js
@@ -50,10 +50,10 @@ module.exports = async function ({ repositoryId, closes = [] }) {
   const { default_branch: base } = await githubQueue(installationId).read(github => github.repos.get({ owner, repo }))
   // find all package.json files on the default branch
   const packageFilePaths = await discoverPackageFilePaths({installationId, fullName: repoDoc.fullName, defaultBranch: base, log})
-  // This mutates repoDoc
-  // Also, this might fail, for example because of a `greenkeeper.json` validation issue
-  // That will throw and end this process!
   try {
+    // This mutates repoDoc!
+    // Also, this might fail, for example because of a `greenkeeper.json` validation issue, but all errors are handled
+    // and the rest of this file will run anyway.
     await updateRepoDoc({installationId, doc: repoDoc, filePaths: packageFilePaths, log})
   } catch (e) {
     // If the config file is invalid, we open an issue instead of the initial PR

--- a/jobs/create-initial-branch.js
+++ b/jobs/create-initial-branch.js
@@ -60,7 +60,7 @@ module.exports = async function ({ repositoryId, closes = [] }) {
     if (e.name && e.name === 'GKConfigFileParseError') {
       log.warn('create initial branch failed because of an invalid config file')
       // We set a flag that the config was borked. When the next push for the greenkeeper.json comes and it is valid
-      // we can tell by the flag whether we still need to open the initial PR that we didn’t do here.
+      // we can tell by the flag whether we still nee2d to open the initial PR that we didn’t do here.
       repoDoc.openInitialPRWhenConfigFileFixed = true
       return invalidConfigFile({
         repoDoc,

--- a/lib/repository-docs.js
+++ b/lib/repository-docs.js
@@ -24,64 +24,67 @@ async function updateRepoDoc ({installationId, doc, filePaths, log}) {
   const oldGreenkeeperConfig = doc.greenkeeper
   // set a default empty config so the job can continue if the file get fails for some reason
   let greenkeeperConfigFile = {}
-  greenkeeperConfigFile = await getGreenkeeperConfigFile(installationId, fullName, log)
-  if (!_.isEmpty(greenkeeperConfigFile)) {
-    log.info('Fetched greenkeeper.json from GitHub', greenkeeperConfigFile)
-  }
-  _.set(doc, ['greenkeeper'], greenkeeperConfigFile)
-  const defaultFiles = {
-    'package.json': [],
-    'package-lock.json': [],
-    'yarn.lock': [],
-    'npm-shrinkwrap.json': []
-  }
-  let filePathsFromConfig = []
-
-  if (!_.isEmpty(greenkeeperConfigFile)) {
-    if (validate(greenkeeperConfigFile).error) {
-      log.info('setting file paths to the ones from the old greenkeeper.json')
-      filePathsFromConfig = getPackagePathsFromConfigFile(oldGreenkeeperConfig)
-    } else {
-      log.info('setting file paths to the ones found via greenkeeper.json')
-      filePathsFromConfig = getPackagePathsFromConfigFile(greenkeeperConfigFile)
+  try {
+    greenkeeperConfigFile = await getGreenkeeperConfigFile(installationId, fullName, log)
+  } catch (e) {
+    throw e
+  } finally {
+    if (!_.isEmpty(greenkeeperConfigFile)) {
+      log.info('Fetched greenkeeper.json from GitHub', greenkeeperConfigFile)
     }
-  }
+    _.set(doc, ['greenkeeper'], greenkeeperConfigFile)
+    const defaultFiles = {
+      'package.json': [],
+      'package-lock.json': [],
+      'yarn.lock': [],
+      'npm-shrinkwrap.json': []
+    }
+    let filePathsFromConfig = []
 
-  // try to get file paths from either the autodiscovered filePaths
-  // or from the greenkeeper.json
-  if (!_.isEmpty(filePaths)) {
-    log.info('setting file paths to the ones found per autodiscovery')
-    filePathsFromConfig = getPackagePathsFromConfigFile({groups: {default: {packages: filePaths}}})
-  }
-  log.info('requesting files from GitHub', {files: filePathsFromConfig})
-  const filesFromConfig = _.isEmpty(filePathsFromConfig)
-    ? await getFiles(installationId, fullName)
-    : await getFiles(installationId, fullName, filePathsFromConfig)
+    if (!_.isEmpty(greenkeeperConfigFile)) {
+      if (validate(greenkeeperConfigFile).error) {
+        log.info('setting file paths to the ones from the old greenkeeper.json')
+        filePathsFromConfig = getPackagePathsFromConfigFile(oldGreenkeeperConfig)
+      } else {
+        log.info('setting file paths to the ones found via greenkeeper.json')
+        filePathsFromConfig = getPackagePathsFromConfigFile(greenkeeperConfigFile)
+      }
+    }
 
-  const files = _.merge(filesFromConfig, defaultFiles)
-  // handles multiple paths for files like this:
-  // files: {
-  //   package.json: ['package.json', 'backend/package.json', 'frontend/package.json']
-  //   package-lock.json: ['package-lock.json', 'backend/package-lock.json']
-  //   npm-shrinkwrap.json: [],
-  //   yarn.lock: []
-  // }
-  doc.files = _.mapValues(files, fileType => fileType
-    .filter(file => !!file.content)
-    .map(file => file.path))
+    // try to get file paths from either the autodiscovered filePaths
+    // or from the greenkeeper.json
+    if (!_.isEmpty(filePaths)) {
+      log.info('setting file paths to the ones found per autodiscovery')
+      filePathsFromConfig = getPackagePathsFromConfigFile({groups: {default: {packages: filePaths}}})
+    }
+    log.info('requesting files from GitHub', {files: filePathsFromConfig})
+    const filesFromConfig = _.isEmpty(filePathsFromConfig)
+      ? await getFiles(installationId, fullName)
+      : await getFiles(installationId, fullName, filePathsFromConfig)
 
-  // formats *all* the package.json files
-  const pkg = formatPackageJson(files['package.json'])
+    const files = _.merge(filesFromConfig, defaultFiles)
+    // handles multiple paths for files like this:
+    // files: {
+    //   package.json: ['package.json', 'backend/package.json', 'frontend/package.json']
+    //   package-lock.json: ['package-lock.json', 'backend/package-lock.json']
+    //   npm-shrinkwrap.json: [],
+    //   yarn.lock: []
+    // }
+    doc.files = _.mapValues(files, fileType => fileType
+      .filter(file => !!file.content)
+      .map(file => file.path))
 
-  if (!pkg) {
-    _.unset(doc, ['packages'])
+    // formats *all* the package.json files
+    const pkg = formatPackageJson(files['package.json'])
+
+    if (!pkg) {
+      _.unset(doc, ['packages'])
+    } else {
+      _.set(doc, ['packages'], pkg)
+    }
+
     log.info('doc updated', {doc})
-    return doc
   }
-
-  _.set(doc, ['packages'], pkg)
-  log.info('doc updated', {doc})
-  return doc
 }
 
 function createDocs ({ repositories, accountId }) {

--- a/lib/repository-docs.js
+++ b/lib/repository-docs.js
@@ -22,7 +22,9 @@ module.exports = {
 async function updateRepoDoc ({installationId, doc, filePaths, log}) {
   const fullName = doc.fullName
   const oldGreenkeeperConfig = doc.greenkeeper
-  const greenkeeperConfigFile = await getGreenkeeperConfigFile(installationId, fullName, log)
+  // set a default empty config so the job can continue if the file get fails for some reason
+  let greenkeeperConfigFile = {}
+  greenkeeperConfigFile = await getGreenkeeperConfigFile(installationId, fullName, log)
   if (!_.isEmpty(greenkeeperConfigFile)) {
     log.info('Fetched greenkeeper.json from GitHub', greenkeeperConfigFile)
   }

--- a/test/lib/repository-docs.js
+++ b/test/lib/repository-docs.js
@@ -30,11 +30,13 @@ test('updateRepoDoc with package.json', async () => {
       content: Buffer.from(JSON.stringify({ name: 'test2' })).toString('base64')
     })
 
-  const doc = await updateRepoDoc({
+  let doc = { fullName: 'owner/repo' }
+  const args = {
     installationId: '123',
-    doc: { fullName: 'owner/repo' },
+    doc,
     log: {info: () => {}, warn: () => {}, error: () => {}}
-  })
+  }
+  await updateRepoDoc(args)
   expect(doc.packages['package.json'].name).toEqual('test')
   expect(doc.files['package-lock.json']).toHaveLength(1)
   expect(doc.files['package.json']).toHaveLength(1)
@@ -59,18 +61,20 @@ test('get invalid package.json', async () => {
       content: Buffer.from('test').toString('base64')
     })
 
-  const doc = await updateRepoDoc({
-    installationId: '123',
-    doc: {
-      fullName: 'owner/repo',
-      packages: {
-        'package.json': {
-          name: 'test'
-        }
+  let doc = {
+    fullName: 'owner/repo',
+    packages: {
+      'package.json': {
+        name: 'test'
       }
-    },
+    }
+  }
+  const args = {
+    installationId: '123',
+    doc,
     log: {info: () => {}, warn: () => {}, error: () => {}}
-  })
+  }
+  await updateRepoDoc(args)
 
   expect(doc.packages).not.toContain('package.json')
   expect(doc.packages).toMatchObject({})
@@ -133,11 +137,14 @@ test('updateRepoDoc with greenkeeper.json present', async () => {
       name: 'package.json',
       content: Buffer.from(JSON.stringify({ name: 'three' })).toString('base64')
     })
-  const doc = await updateRepoDoc({
+
+  let doc = { fullName: 'owner/repo' }
+  const args = {
     installationId: '123',
-    doc: { fullName: 'owner/repo' },
+    doc,
     log: {info: () => {}, warn: () => {}, error: () => {}}
-  })
+  }
+  await updateRepoDoc(args)
   expect(Object.keys(doc.packages)).toHaveLength(3)
   expect(doc.packages['apps/backend/hapiserver/package.json'].name).toEqual('one')
   expect(doc.packages['apps/backend/bla/package.json'].name).toEqual('two')


### PR DESCRIPTION
This should fix #691 

The issue was that when the `greenkeeper.json` is invalid, we don’t return an empty object out of `get-files.js`, but an error. One level up, we then leave `greenkeeperConfigFile` undefined, which prevents everything else from happening. 