### PR TITLE
fix(handle-branch-status): don't comment multiple times

### DIFF
--- a/lib/handle-branch-status.js
+++ b/lib/handle-branch-status.js
@@ -1,4 +1,5 @@
 const _ = require('lodash')
+const Log = require('gk-log')
 
 const getInfos = require('./get-infos')
 const openIssue = require('./open-issue')
@@ -11,6 +12,8 @@ module.exports = async function (
   { installationId, accountId, repository, branchDoc, combined }
 ) {
   const { repositories, npm } = await dbs()
+  const logs = dbs.getLogsDb()
+  const log = Log({logsDb: logs, accountId, repoSlug: repository.fullName, context: 'handle-branch-status'})
   const [owner, repo] = repository.full_name.split('/')
   const repositoryId = String(repository.id)
   const {
@@ -23,7 +26,7 @@ module.exports = async function (
     dependencyType
   } = branchDoc
   const ghqueue = githubQueue(installationId)
-
+  log.info('started')
   const issue = _.get(
     await repositories.query('issue_open_by_dependency', {
       key: [repositoryId, dependency],
@@ -74,8 +77,8 @@ module.exports = async function (
       repo,
       number,
       body: combined.state === 'success'
-        ? `After pinning to **${version}** your tests are passing again. [Downgrade this dependency 📌](/${owner}/${repo}/compare/${encodeURIComponent(head)}?expand=1).`
-        : `After pinning to **${version}** your tests are still failing. The reported issue _might_ not affect your project. These imprecisions are caused by inconsistent test results.`
+        ? `After pinning ${branchDoc.group ? `group ${branchDoc.group}` : ''} to **${version}** your tests are passing again. [Downgrade this dependency 📌](/${owner}/${repo}/compare/${encodeURIComponent(head)}?expand=1).`
+        : `After pinning ${branchDoc.group ? `group ${branchDoc.group}` : ''} to **${version}** your tests are still failing. The reported issue _might_ not affect your project. These imprecisions are caused by inconsistent test results.`
     }))
 
     statsd.increment('issue_comments')
@@ -119,6 +122,9 @@ module.exports = async function (
   const bodyDetails = _.compact(['\n', release, diffCommits]).join('\n')
 
   if (combined.state === 'failure') {
+    if (hasVersionComment(issue, version)) {
+      return
+    }
     await ghqueue.write(github => github.issues.createComment({
       owner,
       repo,
@@ -146,4 +152,12 @@ module.exports = async function (
 
   // Not closing the issue, so decision whether to explicitly upgrade or just close is with the user
   // await github.issues.edit({owner, repo, number, state: 'closed'})
+
+  function hasVersionComment (issue, version) {
+    if (!issue.version || !issue.comments) {
+      log.error('no version information on issue document', {issue})
+      return false
+    }
+    return issue.version === version || issue.comments.includes(version)
+  }
 }


### PR DESCRIPTION
for multiple group version branches + mention the group name (if there is one) in the pinning comment