### PR TITLE
fix: merge repoDoc configs correctly

### DIFF
--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -1,17 +1,15 @@
 const _ = require('lodash')
+const mergejson = require('mergejson')
 const { defaultCommitMessages } = require('./default-commit-messages')
 
 module.exports = repository => {
-  const config = _.has(repository, 'greenkeeper')
-  ? _.get(repository, 'greenkeeper')
-  : _.get(
-    repository,
-    ['packages', 'package.json', 'greenkeeper'],
-    {}
-  )
+  const greenkeeperConfig = _.get(repository, 'greenkeeper', {})
+  const packageJSONConfig = _.get(repository, ['packages', 'package.json', 'greenkeeper'], {})
+
+  const mergedConfig = mergejson(greenkeeperConfig, packageJSONConfig)
 
   // Make a copy instead of mutating the original repoDoc config!
-  return _.defaultsDeep(JSON.parse(JSON.stringify(config)), {
+  return _.defaultsDeep(JSON.parse(JSON.stringify(mergedConfig)), {
     label: 'greenkeeper',
     branchPrefix: 'greenkeeper/',
     ignore: [],

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "json-in-place": "^1.0.1",
     "jsonwebtoken": "^8.1.1",
     "lodash": "^4.16.1",
+    "mergejson": "^1.0.30",
     "nodemailer": "^4.0.1",
     "npm-registry-client": "^8.3.0",
     "pouchdb-http": "^6.0.2",

--- a/test/lib/get-config.js
+++ b/test/lib/get-config.js
@@ -31,7 +31,7 @@ test('get default config', () => {
   expect(getConfig(repository)).toEqual(expected)
 })
 
-test('get config from  root greenkeeper section', () => {
+test('get config from root greenkeeper section', () => {
   expect.assertions(1)
 
   const repository = {
@@ -112,5 +112,76 @@ test('get custom commit message', () => {
     }
   }
   expect(getConfig(repository)).toEqual(expected)
+})
+
+test('get ignore config with empty greenkeeper config', () => {
+  expect.assertions(1)
+
+  const repository = {
+    _id: '51',
+    accountId: '123',
+    fullName: 'treasure-data/td-js-sdk',
+    packages: {
+      'package.json': {
+        greenkeeper: {
+          ignore: ['domready', 'karma', 'mocha']
+        },
+        'devDependencies': {
+          'expect.js': '^0.3.1',
+          'express': '^4.14.0',
+          'glob': '^7.0.5',
+          'js-polyfills': '^0.1.34',
+          'karma': '1.3.0',
+          'karma-browserstack-launcher': '^1.3.0',
+          'karma-chrome-launcher': '^2.2.0',
+          'karma-firefox-launcher': '^1.0.1',
+          'karma-min-reporter': '^0.1.0',
+          'karma-mocha': '^1.3.0',
+          'karma-safari-launcher': '^1.0.0',
+          'karma-webpack': '^2.0.4',
+          'mocha': '^2.5.3',
+          'parse-domain': '^2.0.0',
+          'phantomjs-prebuilt': '^2.1.7',
+          'requirejs': '^2.2.0',
+          'selenium-standalone': '^5.4.0',
+          'simple-mock': '^0.8.0',
+          'standard': '^11.0.0',
+          'tape': '^4.6.0',
+          'uglifyjs': '^2.4.10',
+          'uglifyjs-webpack-plugin': '^0.4.6',
+          'wd': '^1.5.0',
+          'webpack': '^1.13.1'
+        },
+        'dependencies': {
+          'domready': '^0.3.0',
+          'global': '^4.3.0',
+          'json3': '^3.3.2',
+          'jsonp': '0.2.1',
+          'lodash-compat': '^3.10.1'
+        }
+      }
+    },
+    greenkeeper: {}
+  }
+
+  const expected = {
+    label: 'greenkeeper',
+    branchPrefix: 'greenkeeper/',
+    ignore: ['domready', 'karma', 'mocha'],
+    commitMessages: {
+      addConfigFile: 'chore: add Greenkeeper config file',
+      updateConfigFile: 'chore: update Greenkeeper config file',
+      initialBadge: 'docs(readme): add Greenkeeper badge',
+      initialDependencies: 'chore(package): update dependencies',
+      initialBranches: 'chore(travis): whitelist greenkeeper branches',
+      dependencyUpdate: 'fix(package): update ${dependency} to version ${version}',
+      devDependencyUpdate: 'chore(package): update ${dependency} to version ${version}',
+      dependencyPin: 'fix: pin ${dependency} to ${oldVersion}',
+      devDependencyPin: 'chore: pin ${dependency} to ${oldVersion}',
+      closes: '\n\nCloses #${number}'
+    }
+  }
+
+  expect(getConfig(repository)).toMatchObject(expected)
 })
 /* eslint-enable no-template-curly-in-string */


### PR DESCRIPTION
There was a small bug where an empty object in the `greenkeeper` key would prevent config data from the `package.json` config (`packages -> package.json -> greenkeeper -> stuff`) being fetched. See the two new tests for details.

First encountered [here](https://github.com/treasure-data/td-js-sdk/pull/105).