### PR TITLE
fix(pr): show dependency name for scoped packages

### DIFF
--- a/content/fail-issue.js
+++ b/content/fail-issue.js
@@ -37,7 +37,7 @@ module.exports = ({version, dependencyLink, owner, repo, base, head, dependency,
       Dependency
     </td>
     <td>
-      ${dependency}
+      <code>${dependency}</code>
     </td>
   </tr>
   <tr>

--- a/content/update-pr.js
+++ b/content/update-pr.js
@@ -8,15 +8,15 @@ module.exports = ({version, dependencyLink, dependency, oldVersionResolved, type
   <tr>
     <th align=left>
       Dependency
-    </td>
+    </th>
     <td>
-      ${dependency}
+      <code>${dependency}</code>
     </td>
   </tr>
   <tr>
     <th align=left>
       Current Version
-    </td>
+    </th>
     <td>
       ${oldVersionResolved}
     </td>
@@ -24,7 +24,7 @@ module.exports = ({version, dependencyLink, dependency, oldVersionResolved, type
   <tr>
     <th align=left>
       Type
-    </td>
+    </th>
     <td>
       ${type.replace(/ies$/, 'y')}
     </td>


### PR DESCRIPTION
wrap the name in `<code>` to avoid GitHub Markdown rendering bug
closes #635