### PR TITLE
WIP: dynamic spam list

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ const Queue = require('promise-queue')
 
 const env = require('./lib/env')
 const dbs = require('./lib/dbs')
+const getSpamList = require('./lib/spam-list')
 const statsd = require('./lib/statsd')
 require('./lib/rollbar')
 
@@ -78,8 +79,14 @@ require('./lib/rollbar')
     }
   }
 
+  // ['23046691', '1623538', '133018953', 'dalavanmanphonsy', 'CNXTEoEorg', 'tectronics']
+  let spamQueueIds = await getSpamList()
+
   setTimeout(scheduleReminders, 5000)
   setInterval(scheduleReminders, 24 * 60 * 60 * 1000)
+  setInterval(async () => {
+    spamQueueIds = await getSpamList()
+  }, 60 * 1000)
 
   async function consume (job) {
     const data = JSON.parse(job.content.toString())
@@ -109,7 +116,7 @@ require('./lib/rollbar')
         throw e
       }
     }
-    const spamQueueIds = ['23046691', '1623538', '133018953', 'dalavanmanphonsy', 'CNXTEoEorg', 'tectronics']
+
     if (spamQueueIds.includes(String(queueId))) {
       // spam
       channel.ack(job)

--- a/lib/spam-list.js
+++ b/lib/spam-list.js
@@ -1,0 +1,8 @@
+const dbs = require('./dbs')
+
+module.exports = async function getSpamList () {
+  const { gk } = dbs()
+  return gk.get('spam')
+  .then(spamDoc => spamDoc.spam)
+  .catch(() => {})
+}


### PR DESCRIPTION
Instead of hardcoding a list of spammer ids and names, we read them from the database.

This allows faster response times when we don’t have to wait for a full stage/prod deploy cycle.

The list of spammers is updated every minute, to reduce db load.

WIP because we still need to figure out how to bootstrap this cleanly, e.g. how to get the doc set up automatically.

