### PR TITLE
fix(deprecate-node): identify correct node versions in deprecation

### DIFF
--- a/jobs/deprecate-nodejs-version.js
+++ b/jobs/deprecate-nodejs-version.js
@@ -76,7 +76,7 @@ module.exports = async function ({ repositoryFullName, nodeVersion, codeName, ne
     if (!_.get(travisJSON, 'node_js')) return
 
     const nodeVersionFromYaml = getNodeVersionsFromTravisYML(travisYML)
-    const hasNodeVersion = getNodeVersionIndex(nodeVersionFromYaml.versions, nodeVersion, codeName) !== -1
+    const hasNodeVersion = getNodeVersionIndex(nodeVersionFromYaml.versions, nodeVersion, codeName, true) !== -1
     if (!hasNodeVersion) return
     const updatedTravisYaml = addNewLowestAndDeprecate({
       travisYML,
@@ -90,10 +90,11 @@ module.exports = async function ({ repositoryFullName, nodeVersion, codeName, ne
 
   function nvmrcTransform (nvmrc) {
     if (!nvmrc) return nvmrc
-    if (hasNodeVersion(nvmrc, nodeVersion, codeName)) return nvmrc
-
-    const updatedNvmrc = updateNodeVersionToNvmrc(newLowestVersion)
-    return updatedNvmrc
+    if (hasNodeVersion(nvmrc, nodeVersion, codeName, true)) {
+      const updatedNvmrc = updateNodeVersionToNvmrc(newLowestVersion)
+      return updatedNvmrc
+    }
+    return nvmrc
   }
 
   let transforms = [

--- a/test/utils/utils.js
+++ b/test/utils/utils.js
@@ -6,7 +6,8 @@ const {
   getOldVersionResolved,
   getNodeVersionsFromTravisYML,
   addNodeVersionToTravisYML,
-  addNewLowestAndDeprecate
+  addNewLowestAndDeprecate,
+  hasNodeVersion
 } = require('../../utils/utils')
 
 const { cleanCache } = require('../helpers/module-cache-helpers')
@@ -1511,4 +1512,66 @@ after_success: npm run deploy`
     newLowestCodeName: 'Boron'
   })
   expect(updatedYML).toEqual(targetYML)
+})
+
+describe('correctly upgrade node version in .nvmrc', () => {
+  test('Don’t upgrade from 9', () => {
+    const hasNode = hasNodeVersion('9', '4', 'Argon', true)
+    expect(hasNode).toBeFalsy()
+  })
+
+  test('Don’t upgrade from v9', () => {
+    const hasNode = hasNodeVersion('v9', '4', 'Argon', true)
+    expect(hasNode).toBeFalsy()
+  })
+
+  test('Don’t upgrade from - 9', () => {
+    const hasNode = hasNodeVersion('- 9', '4', 'Argon', true)
+    expect(hasNode).toBeFalsy()
+  })
+
+  test('Don’t upgrade from - v9', () => {
+    const hasNode = hasNodeVersion('- v9', '4', 'Argon', true)
+    expect(hasNode).toBeFalsy()
+  })
+
+  test('Do upgrade from 4', () => {
+    const hasNode = hasNodeVersion('4', '4', 'Argon', true)
+    expect(hasNode).toBeTruthy()
+  })
+
+  test('Do upgrade from v4', () => {
+    const hasNode = hasNodeVersion('v4', '4', 'Argon', true)
+    expect(hasNode).toBeTruthy()
+  })
+
+  test('Do upgrade from 4.1.2', () => {
+    const hasNode = hasNodeVersion('4.1.2', '4', 'Argon', true)
+    expect(hasNode).toBeTruthy()
+  })
+
+  test('Do upgrade from v4.1.2', () => {
+    const hasNode = hasNodeVersion('v4.1.2', '4', 'Argon', true)
+    expect(hasNode).toBeTruthy()
+  })
+
+  test('Do upgrade from - 4', () => {
+    const hasNode = hasNodeVersion('- 4', '4', 'Argon', true)
+    expect(hasNode).toBeTruthy()
+  })
+
+  test('Do upgrade from - v4', () => {
+    const hasNode = hasNodeVersion('- v4', '4', 'Argon', true)
+    expect(hasNode).toBeTruthy()
+  })
+
+  test('Do upgrade from - 4.1.2', () => {
+    const hasNode = hasNodeVersion('- 4.1.2', '4', 'Argon', true)
+    expect(hasNode).toBeTruthy()
+  })
+
+  test('Do upgrade from - v4.1.2', () => {
+    const hasNode = hasNodeVersion('- v4.1.2', '4', 'Argon', true)
+    expect(hasNode).toBeTruthy()
+  })
 })


### PR DESCRIPTION
- The regex didn’t handle things like `4.1.2` due to the extra `$` at the end
- `hasNodeVersion()` previously included wildcard strings like `stable` and `node` which always refer to the latest release, but we don’t always want that, so that’s a flag now. That also needed to propagate through `getNodeVersionIndex()`, which calls `hasNodeVersion()`