### PR TITLE
fix: permit periods in package paths

### DIFF
--- a/lib/validate-greenkeeper-json.js
+++ b/lib/validate-greenkeeper-json.js
@@ -3,7 +3,7 @@ const Joi = require('joi')
 // a package path is either the term 'package.json' or
 // a releative path that ends in package.json
 // alternative regex: ^([^/]|p).*ackage\.json$
-const packagePathSchema = Joi.string().regex(/^([a-zA-Z0-9_@-]+\/[a-zA-Z0-9_@/-]*)?package\.json$/)
+const packagePathSchema = Joi.string().regex(/^([.a-zA-Z0-9_@-]+\/[.a-zA-Z0-9_@/-]*)?package\.json$/)
 
 const schema = Joi.object().keys({
   groups: Joi.object().pattern(/^[a-zA-Z0-9_-]+$/,

--- a/test/lib/validate-greenkeeper-json.js
+++ b/test/lib/validate-greenkeeper-json.js
@@ -25,7 +25,8 @@ test('valid package paths', () => {
           'lol/WAAAAH/package.json',
           'apps/frontend/react/package.json',
           'oh/no/apps/frontend/react/package.json',
-          'this/is/stupid/oh/no/apps/frontend/react/package.json'
+          'this/is/stupid/oh/no/apps/frontend/react/package.json',
+          'example.com/site_generator/package.json'
         ]
       }
     }


### PR DESCRIPTION
They're valid characters in a directory name.

The single test passes, unfortunately I'm not able to run your test suite so I cannot validate whether all tests pass. While this is as it is we can't use you guys :(