### PR TITLE
fix(validate-greenkeeper-json): add period to allowed chars in issue txt

### DIFF
--- a/lib/validate-greenkeeper-json.js
+++ b/lib/validate-greenkeeper-json.js
@@ -28,7 +28,7 @@ function validate (file) {
         e.formattedMessage = 'It seems as if your `greenkeeper.json` is not valid JSON. You can check the validity of JSON files with [JSONLint](https://jsonlint.com/), for example.'
       }
       if (e.type === 'string.regex.base') {
-        e.formattedMessage = `The package path \`${e.context.value}\` in the group \`${e.path[1]}\` is invalid. It must be a relative path to a \`package.json\` file. The path may not start with a slash, and it must end in \`package.json\`. Allowed characters for a path are alphanumeric, underscores, dashes and the @ symbol (a-zA-Z_-@).`
+        e.formattedMessage = `The package path \`${e.context.value}\` in the group \`${e.path[1]}\` is invalid. It must be a relative path to a \`package.json\` file. The path may not start with a slash, and it must end in \`package.json\`. Allowed characters for a path are alphanumeric, underscores, dashes, periods and the @ symbol (a-zA-Z_-.@).`
       }
       if (e.type === 'string.regex.base' && e.context.value.startsWith('/')) {
         e.formattedMessage = `The package path \`${e.context.value}\` in the group \`${e.path[1]}\` must be relative and not start with a slash.`

--- a/test/lib/validate-greenkeeper-json.js
+++ b/test/lib/validate-greenkeeper-json.js
@@ -177,7 +177,7 @@ test('invalid: path includes invalid chars', () => {
   expect(result.error.details[0].path).toEqual([ 'groups', 'frontend', 'packages', 0 ])
   expect(result.error.details[0].context.value).toEqual('packages/awesome!/package.json')
   expect(result.error.details[0].message).toMatch(/fails to match the required pattern/)
-  expect(result.error.details[0].formattedMessage).toMatch('The package path `packages/awesome!/package.json` in the group `frontend` is invalid. It must be a relative path to a `package.json` file. The path may not start with a slash, and it must end in `package.json`. Allowed characters for a path are alphanumeric, underscores, dashes and the @ symbol (a-zA-Z_-@).')
+  expect(result.error.details[0].formattedMessage).toMatch('The package path `packages/awesome!/package.json` in the group `frontend` is invalid. It must be a relative path to a `package.json` file. The path may not start with a slash, and it must end in `package.json`. Allowed characters for a path are alphanumeric, underscores, dashes, periods and the @ symbol (a-zA-Z_-.@).')
 })
 
 test('invalid: group/s not under group key', () => {


### PR DESCRIPTION
Small extension to #791 , adds the newly allowed period in package paths to the text in the issues for invalid `greenkeeper.json` files.