### PR TITLE
Adding BaseT package to monorepo-definitions

### DIFF
--- a/utils/monorepo-definitions.js
+++ b/utils/monorepo-definitions.js
@@ -137,6 +137,20 @@ const monorepoDefinitions = {
     'babel-plugin-transform-optional-catch-binding',
     'babel-plugin-transform-optional-chaining'
   ],
+  'baset': [
+    'baset',
+    'baset-core',
+    'baset-cli',
+    'baset-vm',
+    'baset-reader-md',
+    'baset-reader-ts',
+    'baset-reader-babel',
+    'baset-baseliner-md',
+    'baset-baseliner-json',
+    'baset-resolver-react',
+    'baset-resolver-pixi',
+    'baset-env-browser'
+  ],
   'jest': [
     'jest',
     'babel-jest',


### PR DESCRIPTION
As mentioned in [this doc](https://greenkeeper.io/docs.html#monorepo-dependencies) greenkeeper groups updates for projects that use monorepo approach for developing.

Tool I develop now is using Lerna in fixed mode, so it seems that it should be in this list in order to provide best experience for developers that use [BaseT](https://github.com/Igmat/baset) and [greenkeeper](https://greenkeeper.io/) together in their projects.

P.S.
Thanks for you great project - it helps a lot:)