### PR TITLE
fix: add missing custom commit messages

### DIFF
--- a/jobs/create-group-version-branch.js
+++ b/jobs/create-group-version-branch.js
@@ -200,10 +200,11 @@ module.exports = async function (
 
         if (!_.get(repository, `packages['${pkg.filename}'].${pkg.type}.${depName}`)) return
 
-        const commitMessageScope = !satisfies && pkg.type === 'dependencies'
-          ? 'fix'
-          : 'chore'
-        let commitMessage = `${commitMessageScope}(package): update ${depName} to version ${version}`
+        const commitMessageKey = !satisfies && pkg.type === 'dependencies'
+          ? 'dependencyUpdate'
+          : 'devDependencyUpdate'
+        const commitMessageValues = { dependency: depName, version }
+        let commitMessage = getMessage(config.commitMessages, commitMessageKey, commitMessageValues)
 
         if (!satisfies && openPR) {
           await upsert(repositories, openPR._id, {

--- a/jobs/create-version-branch.js
+++ b/jobs/create-version-branch.js
@@ -172,10 +172,11 @@ module.exports = async function (
         return null
       }
 
-      const commitMessageScope = !satisfies && dependencyType === 'dependencies'
-        ? 'fix'
-        : 'chore'
-      let commitMessage = `${commitMessageScope}(package): update ${depName} to version ${version}`
+      const commitMessageKey = !satisfies && dependencyType === 'dependencies'
+        ? 'dependencyUpdate'
+        : 'devDependencyUpdate'
+      const commitMessageValues = { dependency: depName, version }
+      let commitMessage = getMessage(config.commitMessages, commitMessageKey, commitMessageValues)
 
       if (!satisfies && openPR) {
         await upsert(repositories, openPR._id, {


### PR DESCRIPTION
We weren’t using `getMessage()` in two places, this is now fixed.

Closes #794 