### PR TITLE
External monorepo definitions and better monorepo wording

### DIFF
--- a/content/fail-issue.js
+++ b/content/fail-issue.js
@@ -18,10 +18,12 @@ ${statuses.map(status => `- ${status.state === 'success' ? '✅' : '❌'} **${st
 </details>
 `
 
-module.exports = ({version, dependencyLink, owner, repo, base, head, dependency, oldVersionResolved, dependencyType, statuses, release, diffCommits}) => {
+module.exports = ({version, dependencyLink, owner, repo, base, head, dependency, oldVersionResolved, dependencyType, statuses, release, diffCommits, monorepoGroupName}) => {
   const compareURL = generateGitHubCompareURL(`${owner}/${repo}`, base, head)
   return md`
-## Version **${version}** of ${dependencyLink} was just published.
+${_.isEmpty(monorepoGroupName)
+  ? `## Version **${version}** of **${dependencyLink}** was just published.`
+  : `## Version **${version}** of the **${monorepoGroupName}** packages was just published.`}
 
 <table>
   <tr>
@@ -34,10 +36,13 @@ module.exports = ({version, dependencyLink, owner, repo, base, head, dependency,
   </tr>
   <tr>
     <th align=left>
-      Dependency
-    </td>
+      ${_.isEmpty(monorepoGroupName)
+        ? 'Dependency'
+        : 'Monorepo release group'
+      }
+    </th>
     <td>
-      <code>${dependency}</code>
+      <code>${monorepoGroupName || dependencyLink}</code>
     </td>
   </tr>
   <tr>
@@ -59,6 +64,9 @@ module.exports = ({version, dependencyLink, owner, repo, base, head, dependency,
 </table>
 
 This version is **covered** by your **current version range** and after updating it in your project **the build failed**.
+
+${!_.isEmpty(monorepoGroupName) && `This monorepo update includes releases of multiple dependencies which all belong to the [${monorepoGroupName} group definition](https://github.com/greenkeeperio/monorepo-definitions).`
+}
 
 ${
   dependencyType === 'dependencies'

--- a/content/update-pr.js
+++ b/content/update-pr.js
@@ -3,16 +3,19 @@ const md = require('./template')
 
 module.exports = ({version, dependencyLink, dependency, monorepoGroupName, release, diffCommits, oldVersionResolved, type}) => md`
 ${_.isEmpty(monorepoGroupName)
-  ? `## Version **${version}** of ${dependencyLink} was just published.`
-  : `## Version **${version}** of ${monorepoGroupName} packages were just published.`}
+  ? `## Version **${version}** of **${dependencyLink}** was just published.`
+  : `## Version **${version}** of the **${monorepoGroupName}** packages was just published.`}
 
 <table>
   <tr>
     <th align=left>
-      Dependency
+      ${_.isEmpty(monorepoGroupName)
+        ? 'Dependency'
+        : 'Monorepo release group'
+      }
     </th>
     <td>
-      <code>${monorepoGroupName || dependency}</code>
+      <code>${monorepoGroupName || dependencyLink}</code>
     </td>
   </tr>
   ${oldVersionResolved
@@ -35,6 +38,9 @@ ${_.isEmpty(monorepoGroupName)
     </td>
   </tr>
 </table>
+
+${!_.isEmpty(monorepoGroupName) && `This monorepo update includes releases of multiple dependencies which all belong to the [${monorepoGroupName} group definition](https://github.com/greenkeeperio/greenkeeper/blob/master/utils/monorepo-definitions.js).`
+}
 
 The version **${version}** is **not covered** by your **current version range**.
 

--- a/content/update-pr.js
+++ b/content/update-pr.js
@@ -39,7 +39,7 @@ ${_.isEmpty(monorepoGroupName)
   </tr>
 </table>
 
-${!_.isEmpty(monorepoGroupName) && `This monorepo update includes releases of multiple dependencies which all belong to the [${monorepoGroupName} group definition](https://github.com/greenkeeperio/greenkeeper/blob/master/utils/monorepo-definitions.js).`
+${!_.isEmpty(monorepoGroupName) && `This monorepo update includes releases of multiple dependencies which all belong to the [${monorepoGroupName} group definition](https://github.com/greenkeeperio/monorepo-definitions).`
 }
 
 The version **${version}** is **not covered** by your **current version range**.

--- a/lib/handle-branch-status.js
+++ b/lib/handle-branch-status.js
@@ -121,7 +121,8 @@ module.exports = async function (
       dependencyLink,
       release,
       diffCommits,
-      statuses: combined.statuses
+      statuses: combined.statuses,
+      monorepoGroupName
     })
     return
   }

--- a/lib/monorepo.js
+++ b/lib/monorepo.js
@@ -3,7 +3,7 @@ const dbs = require('../lib/dbs')
 const env = require('../lib/env')
 const updatedAt = require('../lib/updated-at')
 
-const monorepoBaseDefinitions = require('../utils/monorepo-definitions')
+const monorepoBaseDefinitions = require('greenkeeper-monorepo-definitions')
 
 let dbDefinitions = JSON.parse(JSON.stringify(monorepoBaseDefinitions))
 let dbDefinitionsLastUpdated = 0

--- a/lib/open-issue.js
+++ b/lib/open-issue.js
@@ -27,7 +27,8 @@ module.exports = async function (
     dependencyLink,
     release,
     diffCommits,
-    statuses
+    statuses,
+    monorepoGroupName
   }
 ) {
   const { repositories } = await dbs()
@@ -46,7 +47,8 @@ module.exports = async function (
     dependencyType,
     release,
     diffCommits,
-    statuses
+    statuses,
+    monorepoGroupName
   })
   const { number } = await githubQueue(installationId).write(github => github.issues.create({
     owner,

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
       "/node_modules/",
       "/test/helpers/.*\\.js$"
     ],
-    "collectCoverage": true,
+    "collectCoverage": false,
     "unmockedModulePathPatterns": [
       "<rootDir>/node_modules/nock"
     ],

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "escape-string-regexp": "^1.0.5",
     "github-url-from-git": "^1.4.0",
     "gk-log": "1.4.0",
+    "greenkeeper-monorepo-definitions": "^1.0.0",
     "hot-shots": "^5.0.0",
     "joi": "^13.1.2",
     "js-yaml": "^3.7.0",
@@ -54,7 +55,7 @@
       "/node_modules/",
       "/test/helpers/.*\\.js$"
     ],
-    "collectCoverage": false,
+    "collectCoverage": true,
     "unmockedModulePathPatterns": [
       "<rootDir>/node_modules/nock"
     ],

--- a/test/jobs/create-group-version-branch.js
+++ b/test/jobs/create-group-version-branch.js
@@ -801,8 +801,8 @@ describe('create-group-version-branch', async () => {
       return '1234abcd'
     })
     jest.mock('../../lib/monorepo', () => {
-      jest.mock('../../utils/monorepo-definitions', () => {
-        let monorepoDefinitions = require.requireActual('../../utils/monorepo-definitions')
+      jest.mock('greenkeeper-monorepo-definitions', () => {
+        let monorepoDefinitions = require.requireActual('greenkeeper-monorepo-definitions')
         const newDef = Object.assign(monorepoDefinitions, {
           pouchdb: ['pouchdb', 'pouchdb-core', 'pouchdb-adapter-utils']
         })
@@ -960,8 +960,8 @@ describe('create-group-version-branch', async () => {
       return '1234abcd'
     })
     jest.mock('../../lib/monorepo', () => {
-      jest.mock('../../utils/monorepo-definitions', () => {
-        let monorepoDefinitions = require.requireActual('../../utils/monorepo-definitions')
+      jest.mock('greenkeeper-monorepo-definitions', () => {
+        let monorepoDefinitions = require.requireActual('greenkeeper-monorepo-definitions')
         const newDef = Object.assign(monorepoDefinitions, {
           pouchdb: ['pouchdb', 'pouchdb-core', 'pouchdb-adapter-utils']
         })

--- a/test/jobs/create-version-branch.js
+++ b/test/jobs/create-version-branch.js
@@ -1517,8 +1517,11 @@ describe('create version branch for dependencies from monorepos', () => {
       .optionally()
       .reply(200, {})
       .post('/repos/finnp/test/pulls')
-      .reply(200, () => {
+      .reply(200, (url, payload) => {
+        const PRBody = JSON.parse(payload).body
         // pull request created
+        expect(PRBody).toMatch('## Version **2.0.0** of the flowers packages was just published')
+        expect(PRBody).toMatch('This monorepo update includes releases of multiple dependencies which all belong to the [flowers group definition](https://github.com/greenkeeperio/greenkeeper/blob/master/utils/monorepo-definitions.js).')
         expect(true).toBeTruthy()
         return {
           id: 321,

--- a/test/jobs/create-version-branch.js
+++ b/test/jobs/create-version-branch.js
@@ -1263,8 +1263,8 @@ describe('create version branch for dependencies from monorepos', () => {
     })
 
     jest.mock('../../lib/monorepo', () => {
-      jest.mock('../../utils/monorepo-definitions', () => {
-        let monorepoDefinitions = require.requireActual('../../utils/monorepo-definitions')
+      jest.mock('greenkeeper-monorepo-definitions', () => {
+        let monorepoDefinitions = require.requireActual('greenkeeper-monorepo-definitions')
         const newDef = Object.assign(monorepoDefinitions, {
           colors: ['colors', 'colors-blue', 'colors-red']
         })
@@ -1412,8 +1412,8 @@ describe('create version branch for dependencies from monorepos', () => {
     })
 
     jest.mock('../../lib/monorepo', () => {
-      jest.mock('../../utils/monorepo-definitions', () => {
-        let monorepoDefinitions = require.requireActual('../../utils/monorepo-definitions')
+      jest.mock('greenkeeper-monorepo-definitions', () => {
+        let monorepoDefinitions = require.requireActual('greenkeeper-monorepo-definitions')
         const newDef = Object.assign(monorepoDefinitions, {
           colors: ['colors', 'colors-blue', 'colors-red']
         })
@@ -1520,8 +1520,8 @@ describe('create version branch for dependencies from monorepos', () => {
       .reply(200, (url, payload) => {
         const PRBody = JSON.parse(payload).body
         // pull request created
-        expect(PRBody).toMatch('## Version **2.0.0** of the flowers packages was just published')
-        expect(PRBody).toMatch('This monorepo update includes releases of multiple dependencies which all belong to the [flowers group definition](https://github.com/greenkeeperio/greenkeeper/blob/master/utils/monorepo-definitions.js).')
+        expect(PRBody).toMatch('## Version **2.0.0** of the **flowers** packages was just published')
+        expect(PRBody).toMatch('This monorepo update includes releases of multiple dependencies which all belong to the [flowers group definition](https://github.com/greenkeeperio/monorepo-definitions).')
         expect(true).toBeTruthy()
         return {
           id: 321,
@@ -1589,8 +1589,8 @@ describe('create version branch for dependencies from monorepos', () => {
     })
 
     jest.mock('../../lib/monorepo', () => {
-      jest.mock('../../utils/monorepo-definitions', () => {
-        let monorepoDefinitions = require.requireActual('../../utils/monorepo-definitions')
+      jest.mock('greenkeeper-monorepo-definitions', () => {
+        let monorepoDefinitions = require.requireActual('greenkeeper-monorepo-definitions')
         const newDef = Object.assign(monorepoDefinitions, {
           flowers: ['flowers', 'flowers-blue', 'flowers-red', 'flowers-green']
         })

--- a/test/jobs/registry-change.js
+++ b/test/jobs/registry-change.js
@@ -557,8 +557,8 @@ describe('monorepo-release: registry change create jobs', async () => {
 
   test('monorepo-release: package is part of complete monorepoDefinition', async () => {
     jest.mock('../../lib/monorepo', () => {
-      jest.mock('../../utils/monorepo-definitions', () => {
-        const monorepoDefinitions = require.requireActual('../../utils/monorepo-definitions')
+      jest.mock('greenkeeper-monorepo-definitions', () => {
+        const monorepoDefinitions = require.requireActual('greenkeeper-monorepo-definitions')
         const newDef = Object.assign(monorepoDefinitions, {
           colors: ['colors', 'colors-blue']
         })
@@ -597,8 +597,8 @@ describe('monorepo-release: registry change create jobs', async () => {
 
   test('monorepo-release: package is part of complete monorepoDefinition, but is not using all the packages', async () => {
     jest.mock('../../lib/monorepo', () => {
-      jest.mock('../../utils/monorepo-definitions', () => {
-        const monorepoDefinitions = require.requireActual('../../utils/monorepo-definitions')
+      jest.mock('greenkeeper-monorepo-definitions', () => {
+        const monorepoDefinitions = require.requireActual('greenkeeper-monorepo-definitions')
         const newDef = Object.assign(monorepoDefinitions, {
           dogs: ['bulldog', 'pug']
         })

--- a/test/lib/monorepo.js
+++ b/test/lib/monorepo.js
@@ -54,7 +54,7 @@ describe('lib monorepo', async () => {
       }
     })
 
-    jest.mock('../../utils/monorepo-definitions', () => {
+    jest.mock('greenkeeper-monorepo-definitions', () => {
       return { 'fruits': ['@avocado/dep', '@banana/dep'] }
     })
     jest.mock('../../lib/monorepo', () => {
@@ -93,8 +93,8 @@ describe('lib monorepo', async () => {
       }
     })
 
-    jest.mock('../../utils/monorepo-definitions', () => {
-      const lib = require.requireActual('../../utils/monorepo-definitions')
+    jest.mock('greenkeeper-monorepo-definitions', () => {
+      const lib = require.requireActual('greenkeeper-monorepo-definitions')
       lib['cities'] = ['koeln', 'hamburg', 'berlin']
       return lib
     })


### PR DESCRIPTION
### Changes:
- uses the new external [greenkeeper-monorepo-definitions module](https://www.npmjs.com/package/greenkeeper-monorepo-definitions)
- adds more monorepo-related information to PRs and issues

![bildschirmfoto 2018-06-12 um 15 15 53](https://user-images.githubusercontent.com/391124/41292704-99bf2e54-6e53-11e8-9ef9-848bd43e4e86.png)
