### PR TITLE
Fix/more reliable db instantiation

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ const Queue = require('promise-queue')
 const env = require('./lib/env')
 const dbs = require('./lib/dbs')
 const statsd = require('./lib/statsd')
-const enterpriseSetup = require('./lib/enterprise-etup')
+const enterpriseSetup = require('./lib/enterprise-setup')
 
 require('./lib/rollbar')
 

--- a/lib/enterprise-setup.js
+++ b/lib/enterprise-setup.js
@@ -1,11 +1,13 @@
+const { resolve } = require('url')
 const PouchDB = require('pouchdb-http')
 
 const env = require('./env')
 
 module.exports = async function () {
   // create /_users if not exists
-  const host = env.COUCHDB_URL
+  const host = env.COUCH_URL
   const dbName = '_users'
-  const users = new PouchDB(`${host}/${dbName}`)
+  const dbUrl = resolve(host, dbName)
+  const users = new PouchDB(dbUrl)
   return users.info()
 }


### PR DESCRIPTION
The bug is the wrongly named env var, but without the introduction of `resolve()`, the error messages is a somewhat confusing `(node:25) UnhandledPromiseRejectionWarning: Error: Invalid Adapter: undefined`, now we get a proper argument error in `resolve()` which should point to the right error.