### PR TITLE
fix: ignore prereleases with latest tag

### DIFF
--- a/jobs/create-group-version-branch.js
+++ b/jobs/create-group-version-branch.js
@@ -36,7 +36,6 @@ module.exports = async function (
     monorepo
   }
 ) {
-  // TODO: correctly handle beta versions, and hotfixes
   if (distTag !== 'latest') return
   // do not upgrade invalid versions
   if (!semver.validRange(oldVersion)) return
@@ -47,6 +46,8 @@ module.exports = async function (
   let relevantDependencies = []
   const groupName = Object.keys(group)[0]
   const version = distTags[distTag]
+  // Ignore releases on `latest` that have prerelease identifiers
+  if (semver.prerelease(version)) return
   const { installations, repositories } = await dbs()
   const logs = dbs.getLogsDb()
   const installation = await installations.get(accountId)

--- a/jobs/create-version-branch.js
+++ b/jobs/create-version-branch.js
@@ -35,16 +35,16 @@ module.exports = async function (
     versions
   }
 ) {
-  // TODO: correctly handle beta versions, and hotfixes
   if (distTag !== 'latest') return
   // do not upgrade invalid versions
   if (!semver.validRange(oldVersion)) return
-
   let isMonorepo = false
   let monorepoGroupName = null
   let monorepoGroup = ''
   let relevantDependencies = []
   const version = distTags[distTag]
+  // Ignore releases on `latest` that have prerelease identifiers
+  if (semver.prerelease(version)) return
   const { installations, repositories } = await dbs()
   const logs = dbs.getLogsDb()
   const installation = await installations.get(accountId)

--- a/jobs/registry-change.js
+++ b/jobs/registry-change.js
@@ -55,7 +55,6 @@ module.exports = async function (
       log.info(`exited: nothing to update, is first release of ${dependency}`)
       return true
     }
-
     return semver.lt(oldVersion, version)
   })
 
@@ -73,11 +72,17 @@ module.exports = async function (
     return
   }
 
+  const version = distTags['latest']
+  // Ignore releases on `latest` that have prerelease identifiers
+  if (semver.prerelease(version)) {
+    log.info(`exited: ${dependency} ${version} is a prerelease on latest`)
+    return
+  }
+
   let dependencies = [ dependency ]
 
   // check if dependency update is part of a monorepo release
   if (await isPartOfMonorepo(dependency)) {
-    const version = distTags['latest']
     // We only want to open a PR if either:
     // 1. We have all of the modules that belong to the release (have the same version number)
     // 2. The release is forced by the monorepo-supervisor. This means the release is still incomplete

--- a/test/jobs/registry-change.js
+++ b/test/jobs/registry-change.js
@@ -125,6 +125,26 @@ describe('registry change create jobs', async () => {
     expect(newJob).toBeFalsy()
   })
 
+  test('registry change skip prereleases in latest', async () => {
+    const newJob = await registryChange({
+      name: 'registry-change',
+      dependency: 'standard',
+      distTags: {
+        latest: '8.0.0-beta.4',
+        next: '8.0.1'
+      },
+      versions: {
+        '8.0.1': {},
+        '8.0.0-beta.4': {
+          gitHead: 'deadbeef'
+        }
+      },
+      registry: 'https://skimdb.npmjs.com/registry'
+    })
+
+    expect(newJob).toBeFalsy()
+  })
+
   test('registry change skip peerDependencies', async () => {
     const { repositories } = await dbs()
 


### PR DESCRIPTION
Problem: people occasionally release prereleases with the `latest` distTag by accident. Nobody wants those releases, so we bail on them now.

# Changes:
- fix: Ignore releases on `latest` that have prerelease identifiers