### PR TITLE
feat(github-events): disable repos when they’re archived

### DIFF
--- a/jobs/github-event/repository/archived.js
+++ b/jobs/github-event/repository/archived.js
@@ -1,0 +1,46 @@
+/*
+
+jobs/github-event/repository/archived.js
+
+Hook receiver for the repository archived event (https://developer.github.com/v3/activity/events/types/#repositoryevent)
+
+When a repository is archived, we want to disable it so Greenkeeper will
+stop trying to act on it when one of its dependencies is updated.
+
+*/
+
+const Log = require('gk-log')
+
+const env = require('../../../lib/env')
+const dbs = require('../../../lib/dbs')
+const { maybeUpdatePaymentsJob } = require('../../../lib/payments')
+const updatedAt = require('../../../lib/updated-at')
+
+module.exports = async function ({ repository }) {
+  const { repositories } = await dbs()
+  const logs = dbs.getLogsDb()
+  const log = Log({logsDb: logs, accountId: repository.owner.id, repoSlug: repository.full_name, context: 'repo-archived'})
+  log.info(`disabling ${repository.full_name}`)
+
+  const repositoryId = String(repository.id)
+  let repoDoc = await repositories.get(repositoryId)
+  repoDoc.enabled = false
+  repoDoc.archived = true
+  await updateDoc(repositories, repository, repoDoc)
+  if (!env.IS_ENTERPRISE) {
+    return maybeUpdatePaymentsJob(repoDoc.accountId, repoDoc.private)
+  }
+
+  function updateDoc (repositories, repository, repoDoc) {
+    return repositories.put(
+      updatedAt(
+        Object.assign(repoDoc, {
+          private: repository.private,
+          fullName: repository.full_name,
+          fork: repository.fork,
+          hasIssues: repository.has_issues
+        })
+      )
+    )
+  }
+}

--- a/test/jobs/github-event/repository/archived.js
+++ b/test/jobs/github-event/repository/archived.js
@@ -40,9 +40,12 @@ test('github-event public repository archived', async () => {
 })
 
 test('github-event private repository archived', async () => {
+  expect.assertions(4)
   jest.mock('../../../../lib/payments', () => {
     const payments = require.requireActual('../../../../lib/payments')
     payments.maybeUpdatePaymentsJob = async () => {
+      // This must be called if the repo is private
+      expect(true).toBeTruthy()
       // pretend this is a private repo with stripe payment
       return Promise.resolve({
         data: {

--- a/test/jobs/github-event/repository/archived.js
+++ b/test/jobs/github-event/repository/archived.js
@@ -1,0 +1,82 @@
+const dbs = require('../../../../lib/dbs')
+const removeIfExists = require('../../../helpers/remove-if-exists')
+
+beforeEach(() => {
+  jest.resetModules()
+})
+
+afterAll(async () => {
+  const { repositories } = await dbs()
+  await removeIfExists(repositories, 'publicRepoToBeArchived', 'privateRepoToBeArchived')
+})
+
+test('github-event public repository archived', async () => {
+  const repoArchived = require('../../../../jobs/github-event/repository/archived')
+  const { repositories } = await dbs()
+
+  await repositories.put({
+    _id: 'publicRepoToBeArchived',
+    enabled: true,
+    private: false,
+    accountId: 'greebles'
+  })
+
+  const newJob = await repoArchived({
+    repository: {
+      id: 'publicRepoToBeArchived',
+      full_name: 'test/test',
+      owner: {
+        id: 1234
+      },
+      private: false
+    }
+  })
+
+  expect(newJob).toBeFalsy()
+  const repo = await repositories.get('publicRepoToBeArchived')
+
+  expect(repo.enabled).toBeFalsy()
+  expect(repo.archived).toBeTruthy()
+})
+
+test('github-event private repository archived', async () => {
+  jest.mock('../../../../lib/payments', () => {
+    const payments = require.requireActual('../../../../lib/payments')
+    payments.maybeUpdatePaymentsJob = async () => {
+      // pretend this is a private repo with stripe payment
+      return Promise.resolve({
+        data: {
+          name: 'update-payments',
+          accountId: 'muppets'
+        }
+      })
+    }
+    return payments
+  })
+  const repoArchived = require('../../../../jobs/github-event/repository/archived')
+  const { repositories } = await dbs()
+
+  await repositories.put({
+    _id: 'privateRepoToBeArchived',
+    enabled: true,
+    private: true,
+    accountId: 'muppets'
+  })
+
+  const newJob = await repoArchived({
+    repository: {
+      id: 'privateRepoToBeArchived',
+      full_name: 'test/test',
+      owner: {
+        id: 1234
+      },
+      private: true
+    }
+  })
+
+  expect(newJob).toBeTruthy()
+  const repo = await repositories.get('privateRepoToBeArchived')
+
+  expect(repo.enabled).toBeFalsy()
+  expect(repo.archived).toBeTruthy()
+})


### PR DESCRIPTION
Cherry-picked from #842 : 

## Features:
- Disables repos when they’re archived. Does not re-enable repos when they’re unarchived, this still requires a reset.