### PR TITLE
Prerelease versions

### DIFF
--- a/jobs/create-group-version-branch.js
+++ b/jobs/create-group-version-branch.js
@@ -12,7 +12,7 @@ const env = require('../lib/env')
 const githubQueue = require('../lib/github-queue')
 const upsert = require('../lib/upsert')
 const { getActiveBilling, getAccountNeedsMarketplaceUpgrade } = require('../lib/payments')
-const { createTransformFunction, getHighestPriorityDependency, generateGitHubCompareURL, hasTooManyPackageJSONs, hasPrerelease } = require('../utils/utils')
+const { createTransformFunction, getHighestPriorityDependency, generateGitHubCompareURL, hasTooManyPackageJSONs } = require('../utils/utils')
 
 const {
   isPartOfMonorepo,
@@ -59,13 +59,6 @@ module.exports = async function (
     log.warn(`exited: repository has ${Object.keys(repository.packages).length} package.json files`)
     return
   }
-
-  // only allow prereleases if there is one defined in package.json
-  const allSavedDependencies = {}
-  group[groupName].packages.forEach((packagePath) => {
-    Object.assign(allSavedDependencies, repository.packages[packagePath])
-  })
-  if (!hasPrerelease(allSavedDependencies) && distTag !== 'latest') return
 
   // if this dependency is part of a monorepo suite that usually gets released
   // all at the same time, check if we have update info for all the other

--- a/jobs/create-version-branch.js
+++ b/jobs/create-version-branch.js
@@ -56,6 +56,9 @@ module.exports = async function (
     return
   }
 
+  console.log('### hasPrerelease', hasPrerelease(repository.packages['package.json']))
+  console.log('### distTag', distTag)
+
   // only allow prereleases if there is one defined in package.json
   if (!hasPrerelease(repository.packages['package.json']) && distTag !== 'latest') return
 

--- a/jobs/create-version-branch.js
+++ b/jobs/create-version-branch.js
@@ -18,7 +18,7 @@ const {
 } = require('../lib/monorepo')
 
 const { getActiveBilling, getAccountNeedsMarketplaceUpgrade } = require('../lib/payments')
-const { createTransformFunction, generateGitHubCompareURL, hasTooManyPackageJSONs } = require('../utils/utils')
+const { createTransformFunction, generateGitHubCompareURL, hasTooManyPackageJSONs, hasPrerelease } = require('../utils/utils')
 
 const prContent = require('../content/update-pr')
 
@@ -35,7 +35,6 @@ module.exports = async function (
     versions
   }
 ) {
-  if (distTag !== 'latest') return
   // do not upgrade invalid versions
   if (!semver.validRange(oldVersion)) return
   let isMonorepo = false
@@ -43,12 +42,12 @@ module.exports = async function (
   let monorepoGroup = ''
   let relevantDependencies = []
   const version = distTags[distTag]
-  // Ignore releases on `latest` that have prerelease identifiers
-  if (semver.prerelease(version)) return
+
   const { installations, repositories } = await dbs()
   const logs = dbs.getLogsDb()
   const installation = await installations.get(accountId)
   const repository = await repositories.get(repositoryId)
+
   const log = Log({logsDb: logs, accountId, repoSlug: repository.fullName, context: 'create-version-branch'})
   log.info(`started for ${dependency} ${version}`, {dependency, type, version, oldVersion})
 
@@ -56,6 +55,10 @@ module.exports = async function (
     log.warn(`exited: repository has ${Object.keys(repository.packages).length} package.json files`)
     return
   }
+
+  // only allow prereleases if there is one defined in package.json
+  if (!hasPrerelease(repository.packages['package.json']) && distTag !== 'latest') return
+
   // if this dependency is part of a monorepo suite that usually gets released
   // all at the same time, check if we have update info for all the other
   // modules as well. If not, stop this update, the job started by the last
@@ -87,6 +90,7 @@ module.exports = async function (
   //
   // See this issue for details: https://github.com/greenkeeperio/greenkeeper/issues/506
 
+  // this is a good candidate for a utils function :)
   function isTrue (x) {
     if (typeof x === 'object') {
       return !!x.length

--- a/jobs/create-version-branch.js
+++ b/jobs/create-version-branch.js
@@ -18,7 +18,7 @@ const {
 } = require('../lib/monorepo')
 
 const { getActiveBilling, getAccountNeedsMarketplaceUpgrade } = require('../lib/payments')
-const { createTransformFunction, generateGitHubCompareURL, hasTooManyPackageJSONs, hasPrerelease } = require('../utils/utils')
+const { createTransformFunction, generateGitHubCompareURL, hasTooManyPackageJSONs } = require('../utils/utils')
 
 const prContent = require('../content/update-pr')
 
@@ -55,12 +55,6 @@ module.exports = async function (
     log.warn(`exited: repository has ${Object.keys(repository.packages).length} package.json files`)
     return
   }
-
-  console.log('### hasPrerelease', hasPrerelease(repository.packages['package.json']))
-  console.log('### distTag', distTag)
-
-  // only allow prereleases if there is one defined in package.json
-  if (!hasPrerelease(repository.packages['package.json']) && distTag !== 'latest') return
 
   // if this dependency is part of a monorepo suite that usually gets released
   // all at the same time, check if we have update info for all the other

--- a/jobs/registry-change.js
+++ b/jobs/registry-change.js
@@ -62,31 +62,32 @@ module.exports = async function (
     log.info(`exited: ${dependency} has no distTag`)
     return
   }
+  console.log('### distTag', distTag)
   await npm.put(updatedAt(Object.assign(npmDbDoc, npmDoc)))
 
-  // currently we only handle latest versions
-  // so we can heavily optimise by exiting here
-  // we want to handle different distTags in the future
-  // if (distTag !== 'latest') {
-  //   log.info(`exited: ${dependency} distTag is ${distTag} (not latest)`)
-  //   return
-  // }
-
-  // const version = distTags['latest']
-
   // get the last version
+  console.log('')
   const version = Object.keys(versions)[Object.keys(versions).length - 1]
-  // Ignore releases on `latest` that have prerelease identifiers
-  // if (semver.prerelease(version)) {
-  //   log.info(`exited: ${dependency} ${version} is a prerelease on latest`)
-  //   return
-  // }
+  console.log('### version', version)
+  const version2 = distTags[distTag]
+  console.log('### version2', version2)
+  console.log('')
+  if (semver.prerelease(version) && distTag === 'latest') {
+    console.info(`exited: ${dependency} ${version} is a prerelease on latest`)
+    log.info(`exited: ${dependency} ${version} is a prerelease on latest`)
+    return
+  }
+
+  if (!semver.prerelease(version) && distTag !== 'latest') {
+    console.info(`exited: ${dependency} ${version} is a non-prerelease on non-latest`)
+    log.info(`exited: ${dependency} ${version} is a non-prerelease on non-latest`)
+    return
+  }
 
   let dependencies = [ dependency ]
 
   // check if dependency update is part of a monorepo release
   if (await isPartOfMonorepo(dependency)) {
-    console.log('### dependency', dependency, version)
     // We only want to open a PR if either:
     // 1. We have all of the modules that belong to the release (have the same version number)
     // 2. The release is forced by the monorepo-supervisor. This means the release is still incomplete

--- a/jobs/registry-change.js
+++ b/jobs/registry-change.js
@@ -63,20 +63,15 @@ module.exports = async function (
     log.info(`exited: ${dependency} has no distTag`)
     return
   }
-  console.log('### distTag', distTag)
   await npm.put(updatedAt(Object.assign(npmDbDoc, npmDoc)))
 
   const version = distTags[distTag]
-  console.log('### version2', version)
-  console.log('')
   if (semver.prerelease(version) && distTag === 'latest') {
-    console.info(`exited: ${dependency} ${version} is a prerelease on latest`)
     log.info(`exited: ${dependency} ${version} is a prerelease on latest`)
     return
   }
 
   if (!semver.prerelease(version) && distTag !== 'latest') {
-    console.info(`exited: ${dependency} ${version} is a non-prerelease on non-latest`)
     log.info(`exited: ${dependency} ${version} is a non-prerelease on non-latest`)
     return
   }

--- a/jobs/registry-change.js
+++ b/jobs/registry-change.js
@@ -49,6 +49,7 @@ module.exports = async function (
   }
 
   const oldDistTags = npmDbDoc.distTags || {}
+  // which distTag has changed
   const distTag = _.findKey(distTags, (version, tag) => {
     const oldVersion = oldDistTags[tag]
     if (!oldVersion) {
@@ -65,12 +66,8 @@ module.exports = async function (
   console.log('### distTag', distTag)
   await npm.put(updatedAt(Object.assign(npmDbDoc, npmDoc)))
 
-  // get the last version
-  console.log('')
-  const version = Object.keys(versions)[Object.keys(versions).length - 1]
-  console.log('### version', version)
-  const version2 = distTags[distTag]
-  console.log('### version2', version2)
+  const version = distTags[distTag]
+  console.log('### version2', version)
   console.log('')
   if (semver.prerelease(version) && distTag === 'latest') {
     console.info(`exited: ${dependency} ${version} is a prerelease on latest`)

--- a/jobs/registry-change.js
+++ b/jobs/registry-change.js
@@ -67,27 +67,31 @@ module.exports = async function (
   // currently we only handle latest versions
   // so we can heavily optimise by exiting here
   // we want to handle different distTags in the future
-  if (distTag !== 'latest') {
-    log.info(`exited: ${dependency} distTag is ${distTag} (not latest)`)
-    return
-  }
+  // if (distTag !== 'latest') {
+  //   log.info(`exited: ${dependency} distTag is ${distTag} (not latest)`)
+  //   return
+  // }
 
-  const version = distTags['latest']
+  // const version = distTags['latest']
+
+  // get the last version
+  const version = Object.keys(versions)[Object.keys(versions).length - 1]
   // Ignore releases on `latest` that have prerelease identifiers
-  if (semver.prerelease(version)) {
-    log.info(`exited: ${dependency} ${version} is a prerelease on latest`)
-    return
-  }
+  // if (semver.prerelease(version)) {
+  //   log.info(`exited: ${dependency} ${version} is a prerelease on latest`)
+  //   return
+  // }
 
   let dependencies = [ dependency ]
 
   // check if dependency update is part of a monorepo release
   if (await isPartOfMonorepo(dependency)) {
+    console.log('### dependency', dependency, version)
     // We only want to open a PR if either:
     // 1. We have all of the modules that belong to the release (have the same version number)
     // 2. The release is forced by the monorepo-supervisor. This means the release is still incomplete
     //    after n minutes, but we want to open the PR anyway
-    if (!await hasAllMonorepoUdates(dependency, version) && !force) {
+    if (!await hasAllMonorepoUdates(dependency, version, distTag) && !force) {
       log.info('exited: is not last in list of monorepo packages')
       // create/update npm/monorepo:dependency-version
       await updateMonorepoReleaseInfo(dependency, distTags, distTag, versions)

--- a/lib/monorepo.js
+++ b/lib/monorepo.js
@@ -39,7 +39,7 @@ async function isPartOfMonorepo (dependency) {
   return !!await module.exports.getMonorepoGroupNameForPackage(dependency)
 }
 
-async function hasAllMonorepoUdates (dependency, version) {
+async function hasAllMonorepoUdates (dependency, version, distTag) {
   const monorepoDefinitions = await getMonorepoDefinitions()
   const { npm } = await dbs()
   try {
@@ -62,12 +62,13 @@ async function hasAllMonorepoUdates (dependency, version) {
       acc[doc._id] = doc
       return acc
     }, {})
-
     // check if we have other monorepo packages
     const receivedAllregistryChanges = monorepoDefinitions[group].reduce((acc, packageName) => {
       const pkg = registryChanges[packageName]
+
+      // aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaah
       // this is the main bit
-      if (pkg && pkg.distTags['latest'] && pkg.distTags['latest'] !== version) {
+      if (pkg && pkg.distTags[distTag] && pkg.distTags[distTag] !== version) {
         return false
       }
       return acc

--- a/lib/monorepo.js
+++ b/lib/monorepo.js
@@ -66,7 +66,6 @@ async function hasAllMonorepoUdates (dependency, version, distTag) {
     const receivedAllregistryChanges = monorepoDefinitions[group].reduce((acc, packageName) => {
       const pkg = registryChanges[packageName]
 
-      // aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaah
       // this is the main bit
       if (pkg && pkg.distTags[distTag] && pkg.distTags[distTag] !== version) {
         return false

--- a/test/jobs/create-version-branch.js
+++ b/test/jobs/create-version-branch.js
@@ -71,6 +71,10 @@ describe('create version branch', () => {
           devDependencies: {
             '@finnpauls/dep': '^1.0.0'
           },
+          dependencies: {
+            '@finnpauls/dep': '^1.1.0',
+            'jest': '^1.0.0-alpha.42'
+          },
           greenkeeper: {
             label: 'customlabel'
           }

--- a/test/jobs/registry-change.js
+++ b/test/jobs/registry-change.js
@@ -22,7 +22,8 @@ describe('registry change create jobs', async () => {
         packages: {
           'package.json': {
             dependencies: {
-              standard: '1.0.0'
+              standard: '1.0.0',
+              betazed: '1.0.0'
             }
           }
         }
@@ -38,6 +39,18 @@ describe('registry change create jobs', async () => {
               standard: '1.0.0'
             }
           }
+        }
+      }),
+      npm.put({
+        _id: 'alphacentauri',
+        distTags: {
+          alpha: '1.0.0'
+        }
+      }),
+      npm.put({
+        _id: 'betazed',
+        distTags: {
+          beta: '1.0.0-.beta.6'
         }
       }),
       npm.put({
@@ -60,7 +73,7 @@ describe('registry change create jobs', async () => {
     await Promise.all([
       removeIfExists(installations, '999', '123-two-packages', '123-two-groups', '123-two-repos'),
       removeIfExists(repositories, '775', '776', '777', '888', '123-monorepo', '123-monorepo-two-groups', 'rg-no-monorepo', 'rg-monorepo'),
-      removeIfExists(npm, 'standard', 'eslint', 'lodash', 'redux')
+      removeIfExists(npm, 'standard', 'eslint', 'lodash', 'redux', 'betazed', 'alphacentauri')
     ])
   })
 
@@ -105,7 +118,7 @@ describe('registry change create jobs', async () => {
     expect(newJob).toBeFalsy()
   })
 
-  test('registry change allow non-latest distTags', async () => {
+  test('registry change allow prereleses in non-latest', async () => {
     const newJobs = await registryChange({
       name: 'registry-change',
       dependency: 'standard',
@@ -141,7 +154,32 @@ describe('registry change create jobs', async () => {
       versions: {
         '8.0.1': {},
         '8.0.0-beta.4': {
-          gitHead: 'deadbeef'
+          gitHead: 'happycow'
+        }
+      },
+      registry: 'https://skimdb.npmjs.com/registry'
+    })
+    expect(newJob).toBeFalsy()
+  })
+
+  test('registry change skip non-prereleases in non-latest', async () => {
+    const newJob = await registryChange({
+      name: 'registry-change',
+      dependency: 'betazed',
+      distTags: {
+        next: '8.0.1',
+        latest: '8.0.0-beta.4',
+        alpha: '8.0.2-alpha.2'
+      },
+      versions: {
+        '8.0.1': {
+          gitHead: 'happycow'
+        },
+        '8.0.0-beta.4': {
+          gitHead: 'happycow'
+        },
+        '8.0.0-alpha.2': {
+          gitHead: 'happycow'
         }
       },
       registry: 'https://skimdb.npmjs.com/registry'
@@ -666,7 +704,7 @@ describe('monorepo-release: registry change create jobs', async () => {
     The reason was that the repo had no root-level `package.json`, and only had `@storybook` deps in one of the multiple `package.json` files.
     It also didn’t depend on `@storybook/vue` directly, only on other `@storybook` packages, but that wan’t relevant in this case.
   */
-  test.skip('monorepo-release: package is part of complete monorepoDefinition, but is only targeting a single non-root package.json', async () => {
+  test('monorepo-release: package is part of complete monorepoDefinition, but is only targeting a single non-root package.json', async () => {
     const { installations, repositories, npm } = await dbs()
 
     await Promise.all([
@@ -746,11 +784,10 @@ describe('monorepo-release: registry change create jobs', async () => {
 
     const newJobs = await registryChange({
       dependency: '@storybook/vue',
-      version: '3.4.7',
       name: 'registry-change',
       distTags: {
         alpha: '4.0.0-alpha.9',
-        latest: '3.4.7',
+        latest: '4.0.0',
         rc: '3.4.0-rc.4'
       },
       versions: {
@@ -791,6 +828,12 @@ describe('monorepo-release: registry change create jobs', async () => {
           }
         },
         '4.0.0-alpha.9': {
+          repository: {
+            type: 'git',
+            url: 'git+https://github.com/storybooks/storybook.git'
+          }
+        },
+        '4.0.0': {
           repository: {
             type: 'git',
             url: 'git+https://github.com/storybooks/storybook.git'

--- a/test/lib/monorepo.js
+++ b/test/lib/monorepo.js
@@ -66,7 +66,7 @@ describe('lib monorepo', async () => {
     })
 
     const libMonorepo = require.requireMock('../../lib/monorepo')
-    const result = await libMonorepo.hasAllMonorepoUdates('@avocado/dep', '2.0.0')
+    const result = await libMonorepo.hasAllMonorepoUdates('@avocado/dep', '2.0.0', 'latest')
     expect(result).toBeTruthy()
   })
 
@@ -107,7 +107,7 @@ describe('lib monorepo', async () => {
     })
 
     const libMonorepo = require.requireMock('../../lib/monorepo')
-    const result = await libMonorepo.hasAllMonorepoUdates('berlin', '2.0.0')
+    const result = await libMonorepo.hasAllMonorepoUdates('berlin', '2.0.0', 'latest')
     expect(result).toBeFalsy()
   })
 

--- a/test/utils/initial-branch-utils.js
+++ b/test/utils/initial-branch-utils.js
@@ -2,34 +2,10 @@ const dbs = require('../../lib/dbs')
 const removeIfExists = require('../helpers/remove-if-exists')
 
 describe('create initial branch', () => {
-  beforeEach(() => {
-    delete process.env.IS_ENTERPRISE
-    delete process.env.BADGES_HOST
-    jest.resetModules()
-  })
-
-  beforeAll(async () => {
-    const { installations, payments } = await dbs()
-
-    await installations.put({
-      _id: '123',
-      installation: 137,
-      plan: 'free'
-    })
-
-    await payments.put({
-      _id: '123',
-      stripeSubscriptionId: 'stripe123',
-      plan: 'personal'
-    })
-  })
-
   afterAll(async () => {
-    const { installations, repositories, payments } = await dbs()
+    const { repositories } = await dbs()
     await Promise.all([
-      removeIfExists(installations, '123'),
-      removeIfExists(payments, '123'),
-      removeIfExists(repositories, '42', '43', '44', '45', '46', '47', '48', '49', '42:branch:1234abcd', '47:branch:1234abcd', '48:branch:1234abcd', '49:branch:1234abcd')
+      removeIfExists(repositories, '49', '49:branch:1234abcd')
     ])
   })
 
@@ -60,11 +36,11 @@ describe('create initial branch', () => {
               latest: '3.0.0-rc1'
             },
             versions: {
+              '1.0.0': true,
               '2.0.0-rc1': true,
               '2.0.0-rc2': true,
               '2.0.0': true,
-              '3.0.0-rc1': true,
-              '1.0.0': true
+              '3.0.0-rc1': true
             }
           }
         }]

--- a/utils/utils.js
+++ b/utils/utils.js
@@ -292,6 +292,13 @@ const addNewLowestAndDeprecate = function ({
 const hasTooManyPackageJSONs = function (repo) {
   return repo.packages && Object.keys(repo.packages).length > 300
 }
+const hasPrerelease = function (packages) {
+  const types = _.omit(packages, 'greenkeeper')
+  if (!types.devDependencies) types.devDependencies = {}
+  if (!types.peerDependencies) types.peerDependencies = {}
+  const allDependenciesInPackageJSON = [...Object.values(types.dependencies), ...Object.values(types.devDependencies), ...Object.values(types.peerDependencies)]
+  return allDependenciesInPackageJSON.some((depName) => depName.includes('-'))
+}
 
 module.exports = {
   seperateNormalAndMonorepos,
@@ -309,5 +316,6 @@ module.exports = {
   removeNodeVersionFromTravisYML,
   updateNodeVersionToNvmrc,
   addNewLowestAndDeprecate,
-  hasTooManyPackageJSONs
+  hasTooManyPackageJSONs,
+  hasPrerelease
 }

--- a/utils/utils.js
+++ b/utils/utils.js
@@ -292,15 +292,6 @@ const addNewLowestAndDeprecate = function ({
 const hasTooManyPackageJSONs = function (repo) {
   return repo.packages && Object.keys(repo.packages).length > 300
 }
-const hasPrerelease = function (packages) {
-  const types = _.omit(packages, 'greenkeeper')
-  if (!types.dependencies) types.dependencies = {}
-  if (!types.devDependencies) types.devDependencies = {}
-  if (!types.peerDependencies) types.peerDependencies = {}
-
-  const allDependenciesInPackageJSON = [...Object.values(types.dependencies), ...Object.values(types.devDependencies), ...Object.values(types.peerDependencies)]
-  return allDependenciesInPackageJSON.some((depName) => depName.includes('-'))
-}
 
 module.exports = {
   seperateNormalAndMonorepos,
@@ -318,6 +309,5 @@ module.exports = {
   removeNodeVersionFromTravisYML,
   updateNodeVersionToNvmrc,
   addNewLowestAndDeprecate,
-  hasTooManyPackageJSONs,
-  hasPrerelease
+  hasTooManyPackageJSONs
 }

--- a/utils/utils.js
+++ b/utils/utils.js
@@ -294,8 +294,10 @@ const hasTooManyPackageJSONs = function (repo) {
 }
 const hasPrerelease = function (packages) {
   const types = _.omit(packages, 'greenkeeper')
+  if (!types.dependencies) types.dependencies = {}
   if (!types.devDependencies) types.devDependencies = {}
   if (!types.peerDependencies) types.peerDependencies = {}
+
   const allDependenciesInPackageJSON = [...Object.values(types.dependencies), ...Object.values(types.devDependencies), ...Object.values(types.peerDependencies)]
   return allDependenciesInPackageJSON.some((depName) => depName.includes('-'))
 }


### PR DESCRIPTION
closes #841 

1. re-allow non-`latest` dist-tag updates through
2. don’t allow non-`latest` dist-tag updates for non-prerelease dependency definitions
3. update only prerelease dependencies with non-`latest` dist-tag updates
4. Ignore initial updates