### PR TITLE
fix(create-version-branch): use group ignore even if not a monorepo

### DIFF
--- a/lib/monorepo.js
+++ b/lib/monorepo.js
@@ -118,6 +118,20 @@ function dateMinusMinutes (minutes) {
   return new Date(new Date().getTime() - minutes * 60000)
 }
 
+// Given a groups array and a package path, returns the package file’s group, or undefined
+function getGroupForPackageFile (groups, packageFilePath) {
+  return Object.keys(groups).find((group) => {
+    return groups[group].packages && groups[group].packages.includes(packageFilePath)
+  })
+}
+
+// Given a groups array, a package path, and a dependency name,
+// returns whether that dep is ignored for that package in any group
+function isDependencyIgnoredInGroups (groups, packageFilePath, dependencyName) {
+  const groupName = getGroupForPackageFile(groups, packageFilePath)
+  return groupName && _.includes(groups[groupName].ignore, dependencyName)
+}
+
 module.exports = {
   isPartOfMonorepo,
   hasAllMonorepoUdates,
@@ -125,5 +139,7 @@ module.exports = {
   getMonorepoGroupNameForPackage,
   updateMonorepoReleaseInfo,
   deleteMonorepoReleaseInfo,
-  pendingMonorepoReleases
+  pendingMonorepoReleases,
+  getGroupForPackageFile,
+  isDependencyIgnoredInGroups
 }

--- a/test/jobs/create-version-branch.js
+++ b/test/jobs/create-version-branch.js
@@ -54,9 +54,8 @@ describe('create version branch', () => {
     await Promise.all([
       removeIfExists(installations, '123', '124', '124gke', '125', '126', '127', '2323'),
       removeIfExists(payments, '124', '125'),
-      removeIfExists(repositories, '1', '41', '42', '43', '44', '45', '46', '47', '48', '49', '50', '51', '86', 'too-many-packages', 'prerelease'),
-      removeIfExists(repositories, '41:branch:1234abcd', '42:branch:1234abcd', '43:branch:1234abcd', '50:branch:1234abcd', '86:branch:1234abcd', '1:branch:2222abcd',
-        '41:pr:321', '50:pr:321', '1:pr:3210')
+      removeIfExists(repositories, '1', '41', '42', '43', '44', '45', '46', '47', '48', '49', '50', '51', '86', 'too-many-packages', 'prerelease', 'ignored-in-group-1'),
+      removeIfExists(repositories, '41:branch:1234abcd', '42:branch:1234abcd', '43:branch:1234abcd', '50:branch:1234abcd', '86:branch:1234abcd', '1:branch:2222abcd', '41:pr:321', '50:pr:321', '1:pr:3210')
     ])
   })
 
@@ -1277,6 +1276,61 @@ describe('create version branch', () => {
     expect(branch).toBeTruthy()
     await expect(repositories.get('86:pr:321')).rejects.toThrow('missing')
     expect(githubMock.isDone()).toBeTruthy()
+  })
+
+  // If it’s not a monorepo, but the user still defines a group for that single package.json, we still
+  // respect its ignore config
+  test('no branch with single package.json in default group and ignored dependency', async () => {
+    const { repositories } = await dbs()
+    await repositories.put({
+      _id: 'ignored-in-group-1',
+      accountId: '2323',
+      fullName: 'finnp/test',
+      enabled: true,
+      greenkeeper: {
+        'groups': {
+          'default': {
+            'packages': [
+              'package.json'
+            ],
+            'ignore': [
+              'karma',
+              'karma-chrome-launcher',
+              'karma-coverage-istanbul-reporter'
+            ]
+          }
+        }
+      },
+      packages: {
+        'package.json': {
+          dependencies: {
+            karma: '5.5.5'
+          }
+        }
+      }
+    })
+
+    const createVersionBranch = require('../../jobs/create-version-branch')
+
+    const newJob = await createVersionBranch({
+      dependency: 'karma',
+      accountId: '2323',
+      repositoryId: 'ignored-in-group-1',
+      type: 'dependencies',
+      distTag: 'latest',
+      distTags: {
+        latest: '5.5.6'
+      },
+      oldVersion: '^5.0.0',
+      oldVersionResolved: '5.5.5',
+      versions: {
+        '5.5.6': {
+          gitHead: 'deadbeef222'
+        }
+      }
+    })
+
+    expect(newJob).toBeFalsy()
   })
 })
 

--- a/test/lib/monorepo.js
+++ b/test/lib/monorepo.js
@@ -231,4 +231,128 @@ describe('lib monorepo', async () => {
     const testAgainGroup = await getMonorepoGroup('gk-test')
     expect(testAgainGroup).toHaveLength(2)
   })
+
+  test('getGroupForPackageFile, has result', async () => {
+    const { getGroupForPackageFile } = await require.requireActual('../../lib/monorepo')
+    const config = {
+      'groups': {
+        'default': {
+          'packages': [
+            'package.json'
+          ],
+          'ignore': [
+            'jasmine-core',
+            'jasmine-spec-reporter',
+            'karma',
+            'karma-chrome-launcher'
+          ]
+        }
+      }
+    }
+    const group = getGroupForPackageFile(config.groups, 'package.json')
+    expect(group).toEqual('default')
+  })
+
+  test('getGroupForPackageFile, has no result', async () => {
+    const { getGroupForPackageFile } = await require.requireActual('../../lib/monorepo')
+    const config = {
+      'groups': {
+        'default': {
+          'packages': [
+            'package.json'
+          ],
+          'ignore': [
+            'jasmine-core',
+            'jasmine-spec-reporter',
+            'karma',
+            'karma-chrome-launcher'
+          ]
+        }
+      }
+    }
+    const group = getGroupForPackageFile(config.groups, 'cats/package.json')
+    expect(group).toBeFalsy()
+  })
+
+  test('isDependencyIgnoredInGroups: yes', async () => {
+    const { isDependencyIgnoredInGroups } = await require.requireActual('../../lib/monorepo')
+    const config = {
+      'groups': {
+        'default': {
+          'packages': [
+            'package.json'
+          ],
+          'ignore': [
+            'jasmine-core',
+            'jasmine-spec-reporter',
+            'karma',
+            'karma-chrome-launcher'
+          ]
+        }
+      }
+    }
+    const isIgnored = isDependencyIgnoredInGroups(config.groups, 'package.json', 'karma')
+    expect(isIgnored).toBeTruthy()
+  })
+
+  test('isDependencyIgnoredInGroups: no', async () => {
+    const { isDependencyIgnoredInGroups } = await require.requireActual('../../lib/monorepo')
+    const config = {
+      'groups': {
+        'default': {
+          'packages': [
+            'package.json'
+          ],
+          'ignore': [
+            'jasmine-core',
+            'jasmine-spec-reporter',
+            'karma',
+            'karma-chrome-launcher'
+          ]
+        }
+      }
+    }
+    const isIgnored = isDependencyIgnoredInGroups(config.groups, 'package.json', 'standard')
+    expect(isIgnored).toBeFalsy()
+  })
+
+  test('isDependencyIgnoredInGroups: groups is empty', async () => {
+    const { isDependencyIgnoredInGroups } = await require.requireActual('../../lib/monorepo')
+    const config = {
+      'groups': {}
+    }
+    const isIgnored = isDependencyIgnoredInGroups(config.groups, 'package.json', 'standard')
+    expect(isIgnored).toBeFalsy()
+  })
+
+  test('isDependencyIgnoredInGroups: ignore is missing', async () => {
+    const { isDependencyIgnoredInGroups } = await require.requireActual('../../lib/monorepo')
+    const config = {
+      'groups': {
+        'default': {
+          'packages': [
+            'package.json'
+          ]
+        }
+      }
+    }
+    const isIgnored = isDependencyIgnoredInGroups(config.groups, 'package.json', 'standard')
+    expect(isIgnored).toBeFalsy()
+  })
+
+  test('isDependencyIgnoredInGroups: ignore is empty', async () => {
+    const { isDependencyIgnoredInGroups } = await require.requireActual('../../lib/monorepo')
+    const config = {
+      'groups': {
+        'default': {
+          'packages': [
+            'package.json'
+          ],
+          'ignore': []
+        }
+      }
+    }
+    const isIgnored = isDependencyIgnoredInGroups(config.groups, 'package.json', 'standard')
+    expect(isIgnored).toBeFalsy()
+  })
 })


### PR DESCRIPTION
We originally didn’t intend for group configurations to be used in non-monorepos, but there’s no reason to not respect ignore rules that come from there, as is the case in #852 

Changes:
- `create-version-branch` bails when a dependency is ignored in a group config that includes the  root `package.json`