### PR TITLE
feat: add customisable initial PR titles

### DIFF
--- a/jobs/create-initial-pr.js
+++ b/jobs/create-initial-pr.js
@@ -9,6 +9,7 @@ const env = require('../lib/env')
 const githubQueue = require('../lib/github-queue')
 const { getActiveBilling, getAccountNeedsMarketplaceUpgrade } = require('../lib/payments')
 const upsert = require('../lib/upsert')
+const { getPrTitle } = require('../lib/get-message')
 
 const prContent = require('../content/initial-pr')
 
@@ -113,9 +114,10 @@ module.exports = async function (
       owner,
       repo,
       title: enabled
-        ? `Add Greenkeeper badge 🌴`
-        : (depsUpdated ? 'Update dependencies' : 'Add badge') +
-            ' to enable Greenkeeper 🌴',
+        ? getPrTitle({ version: 'initialPrBadgeOnly', prTitles: config.prTitles })
+        : (depsUpdated
+          ? getPrTitle({ version: 'initialPR', prTitles: config.prTitles })
+          : getPrTitle({ version: 'initialPrBadge', prTitles: config.prTitles })),
       body: prContent({
         depsUpdated,
         ghRepo,

--- a/jobs/create-initial-subgroup-pr.js
+++ b/jobs/create-initial-subgroup-pr.js
@@ -3,6 +3,7 @@ const Log = require('gk-log')
 const _ = require('lodash')
 
 const getConfig = require('../lib/get-config')
+const { getPrTitle } = require('../lib/get-message')
 const dbs = require('../lib/dbs')
 const env = require('../lib/env')
 const githubQueue = require('../lib/github-queue')
@@ -68,6 +69,10 @@ module.exports = async function (
   const accountTokenUrl = `https://account.greenkeeper.io/status?token=${repodoc.accountToken}`
 
   const files = _.get(repodoc, 'files', {})
+  const title = getPrTitle({
+    version: 'initialSubgroupPR',
+    group: groupName,
+    prTitles: config.prTitles})
 
   // enabled
   try {
@@ -77,7 +82,7 @@ module.exports = async function (
     } = await ghqueue.write(github => github.pullRequests.create({
       owner,
       repo,
-      title: `Update dependencies for ${groupName} 🌴`,
+      title,
       body: prContent({
         depsUpdated,
         ghRepo,

--- a/lib/default-pr-titles.js
+++ b/lib/default-pr-titles.js
@@ -1,5 +1,9 @@
 /* eslint-disable no-template-curly-in-string */
 const defaultPrTitles = {
+  initialPR: 'Update dependencies to enable Greenkeeper 🌴',
+  initialPrBadge: 'Add badge to enable Greenkeeper 🌴',
+  initialPrBadgeOnly: 'Add Greenkeeper badge 🌴',
+  initialSubgroupPR: 'Update dependencies for ${group} 🌴',
   basicPR: 'Update ${dependency} to the latest version 🚀',
   groupPR: 'Update ${dependency} in group ${group} to the latest version 🚀'
 }

--- a/test/lib/get-config.js
+++ b/test/lib/get-config.js
@@ -28,6 +28,10 @@ test('get default config', () => {
       closes: '\n\nCloses #${number}'
     },
     prTitles: {
+      initialPR: 'Update dependencies to enable Greenkeeper 🌴',
+      initialPrBadge: 'Add badge to enable Greenkeeper 🌴',
+      initialPrBadgeOnly: 'Add Greenkeeper badge 🌴',
+      initialSubgroupPR: 'Update dependencies for ${group} 🌴',
       basicPR: 'Update ${dependency} to the latest version 🚀',
       groupPR: 'Update ${dependency} in group ${group} to the latest version 🚀'
     }
@@ -73,6 +77,10 @@ test('get config from root greenkeeper section', () => {
       closes: '\n\nCloses #${number}'
     },
     prTitles: {
+      initialPR: 'Update dependencies to enable Greenkeeper 🌴',
+      initialPrBadge: 'Add badge to enable Greenkeeper 🌴',
+      initialPrBadgeOnly: 'Add Greenkeeper badge 🌴',
+      initialSubgroupPR: 'Update dependencies for ${group} 🌴',
       basicPR: 'Update ${dependency} to the latest version 🚀',
       groupPR: 'Update ${dependency} in group ${group} to the latest version 🚀'
     },
@@ -119,6 +127,10 @@ test('get custom commit message', () => {
       closes: '\n\nCloses #${number}'
     },
     prTitles: {
+      initialPR: 'Update dependencies to enable Greenkeeper 🌴',
+      initialPrBadge: 'Add badge to enable Greenkeeper 🌴',
+      initialPrBadgeOnly: 'Add Greenkeeper badge 🌴',
+      initialSubgroupPR: 'Update dependencies for ${group} 🌴',
       basicPR: 'Update ${dependency} to the latest version 🚀',
       groupPR: 'Update ${dependency} in group ${group} to the latest version 🚀'
     }
@@ -138,7 +150,7 @@ test('get custom pr title', () => {
           },
           prTitles: {
             basicPR: 'update Jacoba to the latest version',
-            groupPR: 'update group of Jacoba to the latest verion'
+            groupPR: 'update group of Jacoba to the latest version'
           }
         }
       }
@@ -162,8 +174,12 @@ test('get custom pr title', () => {
       closes: '\n\nCloses #${number}'
     },
     prTitles: {
+      initialPR: 'Update dependencies to enable Greenkeeper 🌴',
+      initialPrBadge: 'Add badge to enable Greenkeeper 🌴',
+      initialPrBadgeOnly: 'Add Greenkeeper badge 🌴',
+      initialSubgroupPR: 'Update dependencies for ${group} 🌴',
       basicPR: 'update Jacoba to the latest version',
-      groupPR: 'update group of Jacoba to the latest verion'
+      groupPR: 'update group of Jacoba to the latest version'
     }
   }
   expect(getConfig(repository)).toEqual(expected)
@@ -236,6 +252,10 @@ test('get ignore config with empty greenkeeper config', () => {
       closes: '\n\nCloses #${number}'
     },
     prTitles: {
+      initialPR: 'Update dependencies to enable Greenkeeper 🌴',
+      initialPrBadge: 'Add badge to enable Greenkeeper 🌴',
+      initialPrBadgeOnly: 'Add Greenkeeper badge 🌴',
+      initialSubgroupPR: 'Update dependencies for ${group} 🌴',
       basicPR: 'Update ${dependency} to the latest version 🚀',
       groupPR: 'Update ${dependency} in group ${group} to the latest version 🚀'
     }

--- a/test/lib/get-message.js
+++ b/test/lib/get-message.js
@@ -1,4 +1,5 @@
 const {getMessage, getPrTitle} = require('../../lib/get-message')
+const {defaultPrTitles} = require('../../lib/default-pr-titles')
 
 /* eslint-disable no-template-curly-in-string */
 
@@ -81,16 +82,34 @@ describe('custom pr titles', () => {
   const group = 'jacoba'
 
   test('get default pr titles', () => {
-    const defaultPrTitles = {
-      basicPR: 'Update ${dependency} to the latest version 🚀',
-      groupPR: 'Update ${dependency} in group ${group} to the latest version 🚀'
-    }
     const expected = {
+      initialPR: 'Update dependencies to enable Greenkeeper 🌴',
+      initialPrBadge: 'Add badge to enable Greenkeeper 🌴',
+      initialPrBadgeOnly: 'Add Greenkeeper badge 🌴',
+      initialSubgroupPR: 'Update dependencies for jacoba 🌴',
       basicPR: 'Update jacoba to the latest version 🚀',
       groupPR: 'Update jacoba in group jacoba to the latest version 🚀'
     }
 
-    expect.assertions(2)
+    expect.assertions(6)
+
+    expect(getPrTitle({
+      version: 'initialPR',
+      prTitles: defaultPrTitles})).toEqual(expected.initialPR)
+
+    expect(getPrTitle({
+      version: 'initialPrBadge',
+      prTitles: defaultPrTitles})).toEqual(expected.initialPrBadge)
+
+    expect(getPrTitle({
+      version: 'initialPrBadgeOnly',
+      prTitles: defaultPrTitles})).toEqual(expected.initialPrBadgeOnly)
+
+    expect(getPrTitle({
+      version: 'initialSubgroupPR',
+      group,
+      prTitles: defaultPrTitles})).toEqual(expected.initialSubgroupPR)
+
     expect(getPrTitle({
       version: 'basicPR',
       dependency,


### PR DESCRIPTION
Example greenkeeper config object in package.json:
```js
"greenkeeper": {
    "commitMessages": {
      "initialBadge": "Docs: Add Greenkeeper badge",
      "initialDependencies": "Upgrade: Update dependencies",
      "initialBranches": "Build: Whitelist greenkeeper branches",
      "dependencyUpdate": ":gem: Upgrade: Update ${dependency} to version ${version}",
      "devDependencyUpdate": ":gem: Upgrade: Update ${dependency} to version ${version}",
      "dependencyPin": "Fix: Pin ${dependency} to ${oldVersion}",
      "devDependencyPin": "Fix: Pin ${dependency} to ${oldVersion}"
    },
    "prTitles": {
      "initialPR": "Update dependencies to enable Greenkeeper!!!",
      "initialPrBadge": "Add badge to enable Greenkeeper!!!!",
      "initialPrBadgeOnly": "Add Greenkeeper badge!!!",
      "initialSubgroupPR": "Update dependencies for ${group}!!!",
      "basicPR": "Update ${dependency} to the latest!!!",
      "groupPR": "Update ${dependency} in group ${group} to the latest!!!!"
    }
  }
```