### PR TITLE
Fix: scheduling of jobs

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,7 +84,7 @@ require('./lib/rollbar')
     }
   }
 
-  const monorepoSupervisorJobData = Buffer.from(JSON.stringify({name: 'monorepo-supervisor'}))
+  const monorepoSupervisorJobData = { content: Buffer.from(JSON.stringify({name: 'monorepo-supervisor'})) }
   async function scheduleMonorepoReleaseSupervisor () {
     try {
       await scheduleJob(monorepoSupervisorJobData, {priority: 1})

--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ require('./lib/rollbar')
     await enterpriseSetup()
   }
 
-  const scheduleRemindersJobData = Buffer.from(JSON.stringify({name: 'schedule-stale-initial-pr-reminders'}))
+  const scheduleRemindersJobData = { content: Buffer.from(JSON.stringify({name: 'schedule-stale-initial-pr-reminders'})) }
   async function scheduleReminders () {
     try {
       await scheduleJob(scheduleRemindersJobData, {priority: 1})

--- a/jobs/monorepo-supervisor.js
+++ b/jobs/monorepo-supervisor.js
@@ -47,11 +47,13 @@ module.exports = async function () {
     if (release.slack) sendSlackNotification(release.dependency)
 
     return {
-      name: 'registry-change',
-      dependency: release.dependency,
-      distTags: release.distTags,
-      versions: release.versions,
-      force: true
+      data: {
+        name: 'registry-change',
+        dependency: release.dependency,
+        distTags: release.distTags,
+        versions: release.versions,
+        force: true
+      }
     }
   })
 

--- a/jobs/monorepo-supervisor.js
+++ b/jobs/monorepo-supervisor.js
@@ -40,9 +40,9 @@ module.exports = async function () {
 
     return {
       name: 'registry-change',
-      dependency: release.doc.dependency,
-      distTags: release.doc.distTags,
-      versions: release.doc.versions,
+      dependency: release.dependency,
+      distTags: release.distTags,
+      versions: release.versions,
       force: true
     }
   })

--- a/test/jobs/monorepo-supervisor.js
+++ b/test/jobs/monorepo-supervisor.js
@@ -24,39 +24,34 @@ describe('monorepo supervisor', async () => {
       const lib = require.requireActual('../../lib/monorepo')
       lib.pendingMonorepoReleases = () => {
         return [{
-          id: 'monorepo:wobbly',
-          doc: {
-            _id: 'monorepo:wobbly',
-            distTags: {
-              latest: '2.0.0'
+          _id: 'monorepo:wobbly',
+          distTags: {
+            latest: '2.0.0'
+          },
+          versions: {
+            '2.0.0': {
+              gitHead: 'timey'
             },
-            versions: {
-              '2.0.0': {
-                gitHead: 'timey'
-              },
-              '1.0.0': {
-                gitHead: 'wimey'
-              }
+            '1.0.0': {
+              gitHead: 'wimey'
+            }
+          },
+          dependency: 'wobbly'
+        },
+        {
+          _id: 'monorepo:wibbly',
+          distTags: {
+            latest: '2.0.0'
+          },
+          versions: {
+            '2.0.0': {
+              gitHead: 'smurf'
             },
-            dependency: 'wobbly'
-          }
-        }, {
-          id: 'monorepo:wibbly',
-          doc: {
-            _id: 'monorepo:wibbly',
-            distTags: {
-              latest: '2.0.0'
-            },
-            versions: {
-              '2.0.0': {
-                gitHead: 'smurf'
-              },
-              '1.0.0': {
-                gitHead: 'sky'
-              }
-            },
-            dependency: 'wibbly'
-          }
+            '1.0.0': {
+              gitHead: 'sky'
+            }
+          },
+          dependency: 'wibbly'
         }]
       }
       lib.getMonorepoGroupNameForPackage = (dependencyName) => {

--- a/test/jobs/monorepo-supervisor.js
+++ b/test/jobs/monorepo-supervisor.js
@@ -62,9 +62,9 @@ describe('monorepo supervisor', async () => {
     const monorepoSupervisor = require('../../jobs/monorepo-supervisor')
     const newJob = await monorepoSupervisor()
     expect(newJob).toBeTruthy()
-    expect(newJob[0].name).toEqual('registry-change')
-    expect(newJob[0].dependency).toEqual('wobbly')
-    expect(newJob[1].dependency).toEqual('wibbly')
+    expect(newJob[0].data.name).toEqual('registry-change')
+    expect(newJob[0].data.dependency).toEqual('wobbly')
+    expect(newJob[1].data.dependency).toEqual('wibbly')
   })
 
   test('no pending releases', async () => {


### PR DESCRIPTION
- add logs to monorepo-supervisor job
- reformates the scheduled job object to be wrapped in an object with a content key
  - this way the scheduled job can return new jobs!