### PR TITLE
Fix: get latest version for each monorepo release dependency

### DIFF
--- a/test/jobs/create-group-version-branch.js
+++ b/test/jobs/create-group-version-branch.js
@@ -13,7 +13,38 @@ describe('create-group-version-branch', async () => {
   })
 
   beforeAll(async () => {
-    const { installations, repositories } = await dbs()
+    const { installations, repositories, npm } = await dbs()
+    await npm.put({
+      _id: 'react',
+      distTags: {
+        latest: '2.0.0'
+      }
+    })
+    await npm.put({
+      _id: 'pouchdb-core',
+      distTags: {
+        latest: '2.0.0'
+      }
+    })
+    await npm.put({
+      _id: 'pouchdb',
+      distTags: {
+        latest: '2.0.0'
+      }
+    })
+    await npm.put({
+      _id: 'pouchdb-adapter-utils',
+      distTags: {
+        latest: '2.0.0'
+      }
+    })
+    await npm.put({
+      _id: 'pouchdb-browser',
+      distTags: {
+        latest: '1.8.0'
+      }
+    })
+
     await installations.put({
       _id: '123-two-packages',
       installation: 87,
@@ -144,6 +175,40 @@ describe('create-group-version-branch', async () => {
       }
     })
     await repositories.put({
+      _id: '123-monorepo-monorepo-release-different',
+      enabled: true,
+      type: 'repository',
+      fullName: 'hans/monorepo',
+      accountId: '123-two-packages',
+      packages: {
+        'package.json': {
+          dependencies: {
+            'pouchdb': '1.0.0'
+          },
+          devDependencies: {
+            'pouchdb-browser': '1.0.0'
+          },
+          greenkeeper: {
+            'groups': {
+              'default': {
+                'packages': [
+                  'package.json',
+                  'backend/package.json'
+                ]
+              }
+            }
+          }
+        },
+        'backend/package.json': {
+          dependencies: {
+            'pouchdb-browser': '1.0.0',
+            'pouchdb-adapter-utils': '1.0.0',
+            'pouchdb': '1.0.0'
+          }
+        }
+      }
+    })
+    await repositories.put({
       _id: '123-monorepo-monorepo-release-ignore',
       enabled: true,
       type: 'repository',
@@ -178,11 +243,12 @@ describe('create-group-version-branch', async () => {
   })
 
   afterAll(async () => {
-    const { installations, repositories } = await dbs()
+    const { installations, repositories, npm } = await dbs()
 
     await Promise.all([
       removeIfExists(installations, '123-two-packages', '123-two-packages-different-types', '123-dep-ignored-on-group-level'),
-      removeIfExists(repositories, '123-monorepo', '123-monorepo-different-types', '123-monorepo-dep-ignored-on-group-level', '123-monorepo-monorepo-release', 'too-many-packages', 'prerelease'),
+      removeIfExists(npm, 'react', 'pouchdb', 'pouchdb-core', 'pouchdb-adapter-utils', 'pouchdb-browser'),
+      removeIfExists(repositories, '123-monorepo', '123-monorepo-different-types', '123-monorepo-dep-ignored-on-group-level', '123-monorepo-monorepo-release', 'too-many-packages', 'prerelease', '123-monorepo-monorepo-release-different'),
       removeIfExists(repositories, '123-monorepo:branch:1234abcd', '123-monorepo:pr:321', '123-monorepo-different-types:branch:1234abcd', '123-monorepo-different-types:pr:321', '123-monorepo-old-pr')
     ])
   })
@@ -832,19 +898,6 @@ describe('create-group-version-branch', async () => {
 
   test('monorepo release: new pull request, 1 group, 2 packages, same dependencyType', async () => {
     expect.assertions(34)
-    const { npm } = await dbs()
-    await npm.put({
-      _id: 'pouchdb-core',
-      distTags: {
-        latest: '2.0.0'
-      }
-    })
-    await npm.put({
-      _id: 'pouchdb',
-      distTags: {
-        latest: '2.0.0'
-      }
-    })
 
     const githubMock = nock('https://api.github.com')
       .post('/installations/87/access_tokens')
@@ -966,16 +1019,7 @@ describe('create-group-version-branch', async () => {
       expect(result2.dependencies['pouchdb']).toBe('2.0.0')
       return '1234abcd'
     })
-    jest.mock('../../lib/monorepo', () => {
-      jest.mock('greenkeeper-monorepo-definitions', () => {
-        let monorepoDefinitions = require.requireActual('greenkeeper-monorepo-definitions')
-        const newDef = Object.assign(monorepoDefinitions, {
-          pouchdb: ['pouchdb', 'pouchdb-core', 'pouchdb-adapter-utils']
-        })
-        return newDef
-      })
-      return require.requireActual('../../lib/monorepo')
-    })
+
     const createGroupVersionBranch = require('../../jobs/create-group-version-branch')
 
     const newJob = await createGroupVersionBranch({
@@ -1046,6 +1090,205 @@ describe('create-group-version-branch', async () => {
     expect(pr.number).toBe(66)
     expect(pr.state).toEqual('open')
     expect(pr.repositoryId).toEqual('123-monorepo-monorepo-release')
+    expect(pr.accountId).toEqual('123-two-packages')
+  })
+
+  test('monorepo release: new pull request, 1 group, 2 packages, same dependencyType, different versions', async () => {
+    expect.assertions(36)
+
+    const githubMock = nock('https://api.github.com')
+      .post('/installations/87/access_tokens')
+      .optionally()
+      .reply(200, {
+        token: 'secret'
+      })
+      .get('/rate_limit')
+      .optionally()
+      .reply(200, {})
+      .post('/repos/hans/monorepo/pulls')
+      .reply(200, (uri, requestBody) => {
+        // pull request created
+        expect(true).toBeTruthy()
+        expect(JSON.parse(requestBody).title).toEqual('Update pouchdb in group default to the latest version 🚀')
+
+        return {
+          id: 321,
+          number: 66,
+          state: 'open'
+        }
+      })
+      .get('/repos/hans/monorepo')
+      .reply(200, {
+        default_branch: 'master'
+      })
+      .post(
+        '/repos/hans/monorepo/issues/66/labels'
+      )
+      .reply(201, () => {
+        // label created
+        expect(true).toBeTruthy()
+        return {}
+      })
+      .post(
+        '/repos/hans/monorepo/statuses/1234abcd',
+        ({ state }) => state === 'success'
+      )
+      .reply(201, () => {
+        // status created
+        expect(true).toBeTruthy()
+        return {}
+      })
+
+    jest.mock('../../lib/get-infos', () => ({ installationId, dependency, monorepoGroupName, version, diffBase, versions }) => {
+      // used get-infos
+      expect(true).toBeTruthy()
+
+      expect(versions).toEqual({
+        '1.0.0': {},
+        '2.0.0': {}
+      })
+
+      expect(version).toEqual('2.0.0')
+      expect(installationId).toBe(87)
+      expect(monorepoGroupName).toEqual('pouchdb')
+      return {
+        dependencyLink: '[pouchdb]()',
+        release: '2.0.0',
+        diffCommits: `<details>
+         <summary>Commits</summary>
+         body <a href="https://urls.greenkeeper.io/greenkeeperio/greenkeeper">
+       </details>`
+      }
+    })
+    jest.mock('../../lib/create-branch', () => async ({ transforms }) => {
+      expect(transforms).toHaveLength(5)
+
+      const transform0 = await transforms[0]
+      expect(transform0.message).toEqual('fix(package): update pouchdb to version 2.0.0')
+      expect(transform0.path).toEqual('package.json')
+
+      const transform1 = await transforms[1]
+      expect(transform1.message).toEqual('fix(package): update pouchdb to version 2.0.0')
+      expect(transform1.path).toEqual('backend/package.json')
+
+      const transform2 = await transforms[2]
+      expect(transform2.message).toEqual('fix(package): update pouchdb-adapter-utils to version 2.0.0')
+      expect(transform2.path).toEqual('backend/package.json')
+
+      const transform3 = await transforms[3]
+      expect(transform3.message).toEqual('chore(package): update pouchdb-browser to version 1.8.0')
+      expect(transform3.path).toEqual('package.json')
+
+      const transform4 = await transforms[4]
+      expect(transform4.message).toEqual('fix(package): update pouchdb-browser to version 1.8.0')
+      expect(transform4.path).toEqual('backend/package.json')
+
+      let packageJson = {
+        dependencies: {
+          'pouchdb': '1.0.0'
+        },
+        devDependencies: {
+          'pouchdb-browser': '1.0.0'
+        },
+        path: 'package.json'
+      }
+      let backendPackageJson = {
+        dependencies: {
+          'pouchdb': '1.0.0',
+          'pouchdb-browser': '1.0.0',
+          'pouchdb-adapter-utils': '1.0.0'
+        },
+        path: 'backend/package.json'
+      }
+
+      let resultPackageJson = transform0.transform(JSON.stringify(packageJson))
+      resultPackageJson = transform3.transform(resultPackageJson)
+
+      let resultBackendPackageJson = transform1.transform(JSON.stringify(backendPackageJson))
+      resultBackendPackageJson = transform2.transform(resultBackendPackageJson)
+      resultBackendPackageJson = transform4.transform(resultBackendPackageJson)
+
+      resultPackageJson = JSON.parse(resultPackageJson)
+      resultBackendPackageJson = JSON.parse(resultBackendPackageJson)
+
+      expect(resultPackageJson.dependencies['pouchdb']).toBe('2.0.0')
+      expect(resultPackageJson.devDependencies['pouchdb-browser']).toBe('1.8.0')
+      expect(resultBackendPackageJson.dependencies['pouchdb-browser']).toBe('1.8.0')
+      expect(resultBackendPackageJson.dependencies['pouchdb-adapter-utils']).toBe('2.0.0')
+      expect(resultBackendPackageJson.dependencies['pouchdb']).toBe('2.0.0')
+
+      return '1234abcd'
+    })
+    const createGroupVersionBranch = require('../../jobs/create-group-version-branch')
+
+    const newJob = await createGroupVersionBranch({
+      dependency: 'pouchdb-adapter-utils',
+      accountId: '123-two-packages',
+      repositoryId: '123-monorepo-monorepo-release-different',
+      types: [
+        {type: 'dependencies', filename: 'backend/package.json'},
+        {type: 'dependencies', filename: 'package.json'},
+        {type: 'devDependencies', filename: 'package.json'}
+      ],
+      version: '2.0.0',
+      oldVersion: '^1.0.0',
+      oldVersionResolved: '1.0.0',
+      versions: {
+        '1.0.0': {},
+        '2.0.0': {}
+      },
+      group: {
+        'default': {
+          'packages': [
+            'package.json',
+            'backend/package.json'
+          ]
+        }
+      },
+      monorepo: [
+        { id: '123-monorepo-monorepo-release-different',
+          key: 'pouchdb-browser',
+          value: {
+            fullName: 'hans/monorepo',
+            accountId: '123-two-packages',
+            filename: 'package.json',
+            type: 'devDependencies',
+            oldVersion: '1.0.0' } },
+        { id: '123-monorepo-monorepo-release-different',
+          key: 'pouchdb',
+          value: {
+            fullName: 'hans/monorepo',
+            accountId: '123-two-packages',
+            filename: 'package.json',
+            type: 'dependencies',
+            oldVersion: '1.0.0' } },
+        { id: '123-monorepo-monorepo-release-different',
+          key: 'pouchdb-adapter-utils',
+          value: {
+            fullName: 'hans/monorepo',
+            accountId: '123-two-packages',
+            filename: 'backend/package.json',
+            type: 'dependencies',
+            oldVersion: '1.0.0' }
+        }
+      ]
+    })
+
+    expect(githubMock.isDone()).toBeTruthy()
+    expect(newJob).toBeFalsy()
+
+    const { repositories } = await dbs()
+    const branch = await repositories.get('123-monorepo-monorepo-release-different:branch:1234abcd')
+    const pr = await repositories.get('123-monorepo-monorepo-release-different:pr:321')
+
+    expect(branch.processed).toBeTruthy()
+    expect(branch.head).toEqual('greenkeeper/default/monorepo.pouchdb-2.0.0')
+    expect(branch.repositoryId).toEqual('123-monorepo-monorepo-release-different')
+    expect(branch.accountId).toEqual('123-two-packages')
+    expect(branch.dependencyType).toEqual('dependencies')
+    expect(pr.number).toBe(66)
+    expect(pr.state).toEqual('open')
+    expect(pr.repositoryId).toEqual('123-monorepo-monorepo-release-different')
     expect(pr.accountId).toEqual('123-two-packages')
   })
 
@@ -1122,16 +1365,7 @@ describe('create-group-version-branch', async () => {
       expect(transforms).toHaveLength(2)
       return '1234abcd'
     })
-    jest.mock('../../lib/monorepo', () => {
-      jest.mock('greenkeeper-monorepo-definitions', () => {
-        let monorepoDefinitions = require.requireActual('greenkeeper-monorepo-definitions')
-        const newDef = Object.assign(monorepoDefinitions, {
-          pouchdb: ['pouchdb', 'pouchdb-core', 'pouchdb-adapter-utils']
-        })
-        return newDef
-      })
-      return require.requireActual('../../lib/monorepo')
-    })
+
     const createGroupVersionBranch = require('../../jobs/create-group-version-branch')
     const newJob = await createGroupVersionBranch({
       dependency: 'pouchdb-adapter-utils',


### PR DESCRIPTION
because they can be different

it looks up the 'latest' distTag in our npm database for each dependency and sets that as a version. 

maybe it is better to ignore any dependencies that don't match the version that the release is for? 
-> so if the create-version-branch is called with version 2.0.0 and one of the monorepo dependencies is on 1.5.0 then it will not be included in the branch/PR
