### PR TITLE
fix: don’t use upsert to delete documents.

### DIFF
--- a/lib/monorepo.js
+++ b/lib/monorepo.js
@@ -92,9 +92,9 @@ async function deleteMonorepoReleaseInfo (dependency, version) {
   const { npm } = await dbs()
   const monorepoGroupname = await getMonorepoGroupNameForPackage(dependency)
   try {
-    await npm.upsert(`monorepo:${monorepoGroupname}:${version}`, (oldDoc) => {
-      return Object.assign({_deleted: true}, updatedAt(oldDoc))
-    })
+    const docId = `monorepo:${monorepoGroupname}:${version}`
+    const doc = await npm.get(docId)
+    await npm.remove(doc)
   } catch (e) {
     if (e.name !== 'not_found') {
       throw e


### PR DESCRIPTION
upsert’s implementation produces an infinite lopp, if you pass
`_deleted: true`. We don’t want that.