### PR TITLE
fix(create-branch): iterate over package files, not commits

### DIFF
--- a/lib/create-branch.js
+++ b/lib/create-branch.js
@@ -1,5 +1,6 @@
 const statsd = require('./statsd')
 const githubQueue = require('./github-queue')
+const _ = require('lodash')
 
 const { getNewLockfile } = require('../lib/lockfile')
 const { getLockfilePath } = require('../utils/utils')
@@ -86,7 +87,9 @@ module.exports = async (
   if (processLockfiles && repoDoc && repoDoc.files) {
     const logs = dbs.getLogsDb()
     const log = Log({logsDb: logs, accountId: repoDoc.accountId, repoSlug: repoDoc.fullName, context: 'create-branch'})
-    for (const commit of commits) {
+    // we need to iterate over every changed package file, not every package file commit
+    const dedupedCommits = _.sortedUniqBy(commits, commit => commit.path)
+    for (const commit of dedupedCommits) {
       // continue skips the current iteration but continues with the for loop as a whole
       if (!commit.path.includes('package.json')) continue
       const lockfilePath = getLockfilePath(repoDoc.files, commit.path)

--- a/test/lib/__snapshots__/create-branch.js.snap
+++ b/test/lib/__snapshots__/create-branch.js.snap
@@ -24,6 +24,14 @@ Object {
 }
 `;
 
+exports[`create branch with lockfiles don’t generate the same lockfile multiple times 1`] = `
+Object {
+  "lock": "{\\"type\\":\\"Buffer\\",\\"data\\":[123,34,100,101,118,68,101,112,101,110,100,101,110,99,105,101,115,34,58,123,34,106,101,115,116,34,58,34,49,46,49,46,49,34,44,34,119,101,115,116,34,58,34,49,46,49,46,49,34,125,125]}",
+  "packageJson": "{\\"devDependencies\\":{\\"jest\\":\\"^1.0.0\\",\\"west\\":\\"^1.0.0\\"}}",
+  "type": "npm",
+}
+`;
+
 exports[`create branch with lockfiles handle exec server 500 gracefully 1`] = `
 Object {
   "lock": "{\\"type\\":\\"Buffer\\",\\"data\\":[123,34,100,101,118,68,101,112,101,110,100,101,110,99,105,101,115,34,58,123,34,106,101,115,116,34,58,34,49,46,49,46,49,34,125,125]}",


### PR DESCRIPTION
When generating lockfiles, do one per file, not one per commit per file.

Found by @hulkoba , closes #897 