### PR TITLE
Fix/send correct package file to exec

### DIFF
--- a/lib/create-branch.js
+++ b/lib/create-branch.js
@@ -100,15 +100,15 @@ module.exports = async (
       log.info('starting lockfile update', {lockfilePath})
 
       const oldLockfile = await ghqueue.read(github => github.repos.getContent({ path: lockfilePath, owner, repo: repoName }))
-      const oldLockfileContent = Buffer.from(oldLockfile.content, 'base64')
-      log.info('received existing lockfile from GitHub', {oldLockfile})
+      const oldLockfileContent = JSON.stringify(Buffer.from(oldLockfile.content, 'base64'))
+      log.info('received existing lockfile from GitHub')
 
       const isNpm = lockfilePath.includes('package-lock.json')
       try {
-        const {ok, contents} = await getNewLockfile(commit.content, JSON.stringify(oldLockfileContent), isNpm)
+        const {ok, contents} = await getNewLockfile(commit.content, oldLockfileContent, isNpm)
         if (ok) {
           // !ok means the old and new lockfile are the same, so we don’t make a commit
-          log.info('new lockfile contents produced', {contents})
+          log.info('new lockfile contents produced')
           statsd.increment('lockfiles')
           commits.push({
             path: lockfilePath,

--- a/lib/create-branch.js
+++ b/lib/create-branch.js
@@ -80,15 +80,17 @@ module.exports = async (
 
   Transforms array:
   ['readme', 'travis', 'package.json', 'yay/package.json']
-  Commit array with lockfiles:
-  ['readme', 'travis', 'package.json', 'yay/package.json', 'package-lock.json', 'yay/package-lock.json']
+  Commit array with lockfiles (lockfiles are in reverse order):
+  ['readme', 'travis', 'package.json', 'yay/package.json', 'yay/package-lock.json', 'package-lock.json']
 
   */
   if (processLockfiles && repoDoc && repoDoc.files) {
     const logs = dbs.getLogsDb()
     const log = Log({logsDb: logs, accountId: repoDoc.accountId, repoSlug: repoDoc.fullName, context: 'create-branch'})
     // we need to iterate over every changed package file, not every package file commit
-    const dedupedCommits = _.sortedUniqBy(commits, commit => commit.path)
+    // we reverse because we want the most recent commit with the all the changes to the file (the last one)
+    // we clone because we don’t actually want to do the commits backwards
+    const dedupedCommits = _.uniqBy(_.clone(commits).reverse(), commit => commit.path)
     for (const commit of dedupedCommits) {
       // continue skips the current iteration but continues with the for loop as a whole
       if (!commit.path.includes('package.json')) continue
@@ -96,13 +98,14 @@ module.exports = async (
 
       if (!lockfilePath) continue
       log.info('starting lockfile update', {lockfilePath})
-      const updatedPackageFile = repoDoc.packages[commit.path]
+
       const oldLockfile = await ghqueue.read(github => github.repos.getContent({ path: lockfilePath, owner, repo: repoName }))
       const oldLockfileContent = Buffer.from(oldLockfile.content, 'base64')
       log.info('received existing lockfile from GitHub', {oldLockfile})
+
       const isNpm = lockfilePath.includes('package-lock.json')
       try {
-        const {ok, contents} = await getNewLockfile(JSON.stringify(updatedPackageFile), JSON.stringify(oldLockfileContent), isNpm)
+        const {ok, contents} = await getNewLockfile(commit.content, JSON.stringify(oldLockfileContent), isNpm)
         if (ok) {
           // !ok means the old and new lockfile are the same, so we don’t make a commit
           log.info('new lockfile contents produced', {contents})

--- a/test/lib/__snapshots__/create-branch.js.snap
+++ b/test/lib/__snapshots__/create-branch.js.snap
@@ -3,23 +3,23 @@
 exports[`create branch with lockfiles change one file (package.json) and generate its lockfile (old syntax) 1`] = `
 Object {
   "lock": "{\\"type\\":\\"Buffer\\",\\"data\\":[123,34,100,101,118,68,101,112,101,110,100,101,110,99,105,101,115,34,58,123,34,106,101,115,116,34,58,34,49,46,49,46,49,34,125,125]}",
-  "packageJson": "{\\"devDependencies\\":{\\"jest\\":\\"^1.0.0\\"}}",
+  "packageJson": "{\\"devDependencies\\":{\\"jest\\":\\"1.2.0\\"}}",
   "type": "npm",
 }
 `;
 
-exports[`create branch with lockfiles change two file (package.json, frontend/package.json) and generate their lockfiles 1`] = `
+exports[`create branch with lockfiles change two files (package.json, frontend/package.json) and generate their lockfiles 1`] = `
 Object {
   "lock": "{\\"type\\":\\"Buffer\\",\\"data\\":[123,34,100,101,118,68,101,112,101,110,100,101,110,99,105,101,115,34,58,123,34,106,101,115,116,34,58,34,49,46,49,46,49,34,125,125]}",
-  "packageJson": "{\\"devDependencies\\":{\\"jest\\":\\"^1.0.0\\"}}",
+  "packageJson": "{\\"devDependencies\\":{\\"jest\\":\\"1.2.0\\"}}",
   "type": "npm",
 }
 `;
 
-exports[`create branch with lockfiles change two file (package.json, frontend/package.json) and generate their lockfiles 2`] = `
+exports[`create branch with lockfiles change two files (package.json, frontend/package.json) and generate their lockfiles 2`] = `
 Object {
   "lock": "{\\"type\\":\\"Buffer\\",\\"data\\":[123,34,100,101,118,68,101,112,101,110,100,101,110,99,105,101,115,34,58,123,34,106,101,115,116,34,58,34,49,46,49,46,49,34,125,125]}",
-  "packageJson": "{\\"devDependencies\\":{\\"jest\\":\\"^1.0.0\\"}}",
+  "packageJson": "{\\"devDependencies\\":{\\"jest\\":\\"1.2.0\\"}}",
   "type": "npm",
 }
 `;
@@ -27,7 +27,7 @@ Object {
 exports[`create branch with lockfiles don’t generate the same lockfile multiple times 1`] = `
 Object {
   "lock": "{\\"type\\":\\"Buffer\\",\\"data\\":[123,34,100,101,118,68,101,112,101,110,100,101,110,99,105,101,115,34,58,123,34,106,101,115,116,34,58,34,49,46,49,46,49,34,44,34,119,101,115,116,34,58,34,49,46,49,46,49,34,125,125]}",
-  "packageJson": "{\\"devDependencies\\":{\\"jest\\":\\"^1.0.0\\",\\"west\\":\\"^1.0.0\\"}}",
+  "packageJson": "{\\"devDependencies\\":{\\"jest\\":\\"1.2.0\\",\\"west\\":\\"1.5.0\\"}}",
   "type": "npm",
 }
 `;
@@ -35,7 +35,7 @@ Object {
 exports[`create branch with lockfiles handle exec server 500 gracefully 1`] = `
 Object {
   "lock": "{\\"type\\":\\"Buffer\\",\\"data\\":[123,34,100,101,118,68,101,112,101,110,100,101,110,99,105,101,115,34,58,123,34,106,101,115,116,34,58,34,49,46,49,46,49,34,125,125]}",
-  "packageJson": "{\\"devDependencies\\":{\\"jest\\":\\"^1.0.0\\"}}",
+  "packageJson": "{\\"devDependencies\\":{\\"jest\\":\\"1.2.0\\"}}",
   "type": "npm",
 }
 `;

--- a/test/lib/create-branch.js
+++ b/test/lib/create-branch.js
@@ -857,6 +857,7 @@ describe('create branch with lockfiles', async () => {
 
     nock('http://localhost:1234')
       .post('/', (body) => {
+        expect(body.packageJson).toEqual('{"devDependencies":{"jest":"1.2.0"}}')
         expect(typeof body.type).toBe('string')
         expect(typeof body.packageJson).toBe('string')
         expect(typeof body.lock).toBe('string')
@@ -895,7 +896,7 @@ describe('create branch with lockfiles', async () => {
         packages: {
           'package.json': {
             devDependencies: {
-              'jest': '^1.0.0'
+              'jest': '1.0.0'
             }
           }
         }
@@ -906,7 +907,7 @@ describe('create branch with lockfiles', async () => {
     expect(gitHubNock.isDone()).toBeTruthy()
   })
 
-  test('change two file (package.json, frontend/package.json) and generate their lockfiles', async () => {
+  test('change two files (package.json, frontend/package.json) and generate their lockfiles', async () => {
     const packageFileContents = {devDependencies: {
       'jest': '1.1.1'
     }}
@@ -1000,11 +1001,11 @@ describe('create branch with lockfiles', async () => {
       .reply(201, {
         sha: '2-commit'
       })
-      // Third tree and commit for package-lock.json
+      // Third tree and commit for frontend/package-lock.json
       .post('/repos/owner/repo/git/trees', {
         tree: [
           {
-            path: 'package-lock.json',
+            path: 'frontend/package-lock.json',
             content: '{"devDependencies":{"jest": {"version": "1.2.0"}}}',
             mode: '100644',
             type: 'blob'
@@ -1023,11 +1024,11 @@ describe('create branch with lockfiles', async () => {
       .reply(201, {
         sha: '3-commit'
       })
-      // Fourth tree and commit for frontend/package-lock.json
+      // Fourth tree and commit for package-lock.json
       .post('/repos/owner/repo/git/trees', {
         tree: [
           {
-            path: 'frontend/package-lock.json',
+            path: 'package-lock.json',
             content: '{"devDependencies":{"jest": {"version": "1.2.0"}}}',
             mode: '100644',
             type: 'blob'
@@ -1054,6 +1055,7 @@ describe('create branch with lockfiles', async () => {
 
     nock('http://localhost:1234')
       .post('/', (body) => {
+        expect(body.packageJson).toEqual(JSON.stringify(updatedPackageFileContents))
         expect(typeof body.type).toBe('string')
         expect(typeof body.packageJson).toBe('string')
         expect(typeof body.lock).toBe('string')
@@ -1067,6 +1069,7 @@ describe('create branch with lockfiles', async () => {
         }
       })
       .post('/', (body) => {
+        expect(body.packageJson).toEqual(JSON.stringify(updatedPackageFileContents))
         expect(typeof body.type).toBe('string')
         expect(typeof body.packageJson).toBe('string')
         expect(typeof body.lock).toBe('string')
@@ -1113,12 +1116,12 @@ describe('create branch with lockfiles', async () => {
         packages: {
           'package.json': {
             devDependencies: {
-              'jest': '^1.0.0'
+              'jest': '1.0.0'
             }
           },
           'frontend/package.json': {
             devDependencies: {
-              'jest': '^1.0.0'
+              'jest': '1.0.0'
             }
           }
         }
@@ -1132,7 +1135,7 @@ describe('create branch with lockfiles', async () => {
   test('don’t generate the same lockfile multiple times', async () => {
     // multiple commits to the same package file should only result in a single lockfile update,
     // meaning a single exec server request and a single github tree update plus commit
-    expect.assertions(7)
+    expect.assertions(8)
     const packageFileContents = {devDependencies: {
       'jest': '1.1.1',
       'west': '1.1.1'
@@ -1250,6 +1253,7 @@ describe('create branch with lockfiles', async () => {
 
     const execNock = nock('http://localhost:1234')
       .post('/', (body) => {
+        expect(body.packageJson).toEqual(JSON.stringify(updatedPackageFileContents2))
         expect(typeof body.type).toBe('string')
         expect(typeof body.packageJson).toBe('string')
         expect(typeof body.lock).toBe('string')
@@ -1296,8 +1300,8 @@ describe('create branch with lockfiles', async () => {
         packages: {
           'package.json': {
             devDependencies: {
-              'jest': '^1.0.0',
-              'west': '^1.0.0'
+              'jest': '1.0.0',
+              'west': '1.0.0'
             }
           }
         }
@@ -1376,6 +1380,7 @@ describe('create branch with lockfiles', async () => {
 
     nock('http://localhost:1234')
       .post('/', (body) => {
+        expect(body.packageJson).toEqual(JSON.stringify(updatedPackageFileContents))
         expect(typeof body.type).toBe('string')
         expect(typeof body.packageJson).toBe('string')
         expect(typeof body.lock).toBe('string')


### PR DESCRIPTION
## Changes:
- no longer log huge lockfile blobs (slowed down logviewer a loooot)
- we were sending the first package file commit to the exec server, not the last (the one with all the changes)