### PR TITLE
chore(create-branch): don’t log the entire lockfile on error

### DIFF
--- a/lib/create-branch.js
+++ b/lib/create-branch.js
@@ -118,7 +118,7 @@ module.exports = async (
           })
         }
       } catch (e) {
-        log.error('error fetching updated lockfile from exec server', {e})
+        log.error('error fetching updated lockfile from exec server', {e: e.error})
       }
     }
   }


### PR DESCRIPTION
Less spam spam spam spam spam.