### PR TITLE
Feat/more and better logs

### DIFF
--- a/jobs/create-group-version-branch.js
+++ b/jobs/create-group-version-branch.js
@@ -230,6 +230,22 @@ module.exports = async function (
     return
   }
 
+  // If an npm-shrinkwrap.json exists, we bail if semver is satisfied
+  function isTrue (x) {
+    if (typeof x === 'object') {
+      return !!x.length
+    }
+    return x
+  }
+
+  const hasModuleLockFile = repoDoc.files && isTrue(repoDoc.files['npm-shrinkwrap.json'])
+
+  // Bail if it’s in range and the repo uses shrinkwrap
+  if (satisfiesAll && hasModuleLockFile) {
+    log.info(`exited: ${dependency} ${version} satisfies semver & repository has a module lockfile (shrinkwrap type)`)
+    return
+  }
+
   const { default_branch: base } = await ghqueue.read(github => github.repos.get({ owner, repo }))
   log.info('github: using default branch', {defaultBranch: base})
 

--- a/jobs/create-group-version-branch.js
+++ b/jobs/create-group-version-branch.js
@@ -167,13 +167,13 @@ module.exports = async function (
 
         const oldPkgVersion = _.get(repoDoc, `packages['${pkg.filename}'].${pkg.type}.${depName}`)
         if (!oldPkgVersion) {
-          log.warn('exited transform creation: could not find old package version', {newVersion: version})
+          log.warn(`exited transform creation: could not find old package version for ${depName}`, {newVersion: version, dependencyType: pkg.type, packageFile: _.get(repoDoc, `packages['${pkg.filename}']`)})
           return
         }
         const satisfies = semver.satisfies(latestDependencyVersion, oldPkgVersion)
         // no downgrades
         if (semver.ltr(latestDependencyVersion, oldPkgVersion)) {
-          log.warn(`exited transform creation: ${dependency} ${latestDependencyVersion} would be a downgrade from ${oldPkgVersion}`, {newVersion: latestDependencyVersion, oldVersion: oldPkgVersion})
+          log.warn(`exited transform creation: ${depName} ${latestDependencyVersion} would be a downgrade from ${oldPkgVersion}`, {newVersion: latestDependencyVersion, oldVersion: oldPkgVersion})
           return
         }
 
@@ -199,12 +199,12 @@ module.exports = async function (
         })
         const oldVersionResolved = getOldVersionResolved(satisfyingVersions, npmDoc.distTags, 'latest')
         if (!oldVersionResolved) {
-          log.warn('exited transform creation: could not resolve old version (no update?)', {newVersion: version, satisfyingVersions, latestDependencyVersion, oldPkgVersion})
+          log.warn(`exited transform creation: could not resolve old version for ${depName} (no update?)`, {newVersion: version, satisfyingVersions, latestDependencyVersion, oldPkgVersion})
           return null
         }
 
         if (semver.prerelease(latestDependencyVersion) && !semver.prerelease(oldVersionResolved)) {
-          log.info(`exited transform creation: ${dependency} ${latestDependencyVersion} is a prerelease on latest and user does not use prereleases for this dependency`, {latestDependencyVersion, oldPkgVersion})
+          log.info(`exited transform creation: ${depName} ${latestDependencyVersion} is a prerelease on latest and user does not use prereleases for this dependency`, {latestDependencyVersion, oldPkgVersion})
           return null
         }
 

--- a/jobs/create-version-branch.js
+++ b/jobs/create-version-branch.js
@@ -127,7 +127,7 @@ module.exports = async function (
 
       const oldPkgVersion = _.get(json, [dependencyType, depName])
       if (!oldPkgVersion) {
-        log.warn('exited transform creation: could not find old package version', {newVersion: version, json})
+        log.warn(`exited transform creation: could not find old package version for ${depName}`, {newVersion: version, dependencyType, packageFile: _.get(json, [dependencyType])})
         return null
       }
 
@@ -137,7 +137,7 @@ module.exports = async function (
       const repoURL = _.get(npmDoc, `versions['${latestDependencyVersion}'].repository.url`)
 
       if (semver.ltr(latestDependencyVersion, oldPkgVersion)) { // no downgrades
-        log.warn(`exited transform creation: ${dependency} ${latestDependencyVersion} would be a downgrade from ${oldPkgVersion}`, {newVersion: latestDependencyVersion, oldVersion: oldPkgVersion})
+        log.warn(`exited transform creation: ${depName} ${latestDependencyVersion} would be a downgrade from ${oldPkgVersion}`, {newVersion: latestDependencyVersion, oldVersion: oldPkgVersion})
         return null
       }
       const satisfies = semver.satisfies(latestDependencyVersion, oldPkgVersion)
@@ -161,12 +161,12 @@ module.exports = async function (
       })
       const oldVersionResolved = getOldVersionResolved(satisfyingVersions, npmDoc.distTags, 'latest')
       if (!oldVersionResolved) {
-        log.warn('exited transform creation: could not resolve old version (no update?)', {newVersion: version, json, satisfyingVersions, latestDependencyVersion, oldPkgVersion})
+        log.warn(`exited transform creation: could not resolve old version for ${depName} (no update?)`, {newVersion: version, json, satisfyingVersions, latestDependencyVersion, oldPkgVersion})
         return null
       }
 
       if (semver.prerelease(latestDependencyVersion) && !semver.prerelease(oldVersionResolved)) {
-        log.info(`exited transform creation: ${dependency} ${latestDependencyVersion} is a prerelease on latest and user does not use prereleases for this dependency`, {latestDependencyVersion, oldPkgVersion})
+        log.info(`exited transform creation: ${depName} ${latestDependencyVersion} is a prerelease on latest and user does not use prereleases for this dependency`, {latestDependencyVersion, oldPkgVersion})
         return null
       }
 

--- a/jobs/registry-change.js
+++ b/jobs/registry-change.js
@@ -126,16 +126,17 @@ module.exports = async function (
     "oldVersion": "^4.2.4"
   }
   */
-  // packageFilesForUpdatedDependency are a list of all repoDocs that have that dependency (should rename that)
+  // packageFilesForUpdatedDependency are a list of all package files across all repoDocs that have that dependency
   const packageFilesForUpdatedDependency = (await repositories.query('by_dependency', {
     keys: dependencies
   })).rows
 
   if (!packageFilesForUpdatedDependency.length) {
-    // log.info(`exited: no repoDocs found that depend on ${dependency}`)
+    // log.info(`exited: no package files found that depend on ${dependency}`)
     return
   }
   log.info(`found ${packageFilesForUpdatedDependency.length} repoDocs that use ${dependency}`)
+  statsd.gauge('package_files_with_dependency', packageFilesForUpdatedDependency.length, { tag: dependency })
 
   if (packageFilesForUpdatedDependency.length > 100) statsd.event('popular_package')
   // check if package has a greenkeeper.json / more then 1 package json or package.json is in subdirectory

--- a/lib/github-queue.js
+++ b/lib/github-queue.js
@@ -23,19 +23,46 @@ function setupLog () {
   return log
 }
 
+function reportStats (stats) {
+  const waitingInQueue = stats.started - stats.queued
+  const waitingForToken = stats.tokenized - stats.started
+  const waitingForResponse = stats.done - stats.tokenized
+  const waitingForNetwork = stats.done - stats.started
+  const total = stats.done - stats.queued
+  statsd.gauge(`queues.github_${stats.type}_requests_time_in_queue`, waitingInQueue)
+  statsd.gauge(`queues.github_${stats.type}_requests_time_to_token`, waitingForToken)
+  statsd.gauge(`queues.github_${stats.type}_requests_time_to_response`, waitingForResponse)
+  statsd.gauge(`queues.github_${stats.type}_requests_time_in_network`, waitingForNetwork)
+  statsd.gauge(`queues.github_${stats.type}_requests_time_total`, total)
+}
+
 function write (installationId, gen) {
+  statsd.increment('queues.github_write_requests')
+  const stats = {
+    type: 'write',
+    queued: Date.now()
+  }
   try {
     return writeQueue.add(() => {
       return Promise.delay(env.NODE_ENV === 'testing' ? 0 : 1000)
-        .then(() => getToken(installationId))
+        .then(() => {
+          stats.started = Date.now()
+          return getToken(installationId)
+        })
         .then(({token}) => {
+          stats.tokenized = Date.now()
           const github = Github()
           github.authenticate({ type: 'token', token })
           return gen(github)
         })
-        .then(response => response.data)
+        .then(response => {
+          stats.done = Date.now()
+          reportStats(stats)
+          return response.data
+        })
     })
   } catch (e) {
+    statsd.increment('queues.github_write_failures')
     const log = setupLog()
     log.warn('github: write exception', { installationId, exception: e })
     throw e
@@ -43,15 +70,24 @@ function write (installationId, gen) {
 }
 
 function read (installationId, gen) {
+  statsd.increment('queues.github_read_requests')
+  const stats = {
+    type: 'read',
+    queued: Date.now()
+  }
   try {
     return readQueue.add(() => {
+      stats.started = Date.now()
       return getToken(installationId)
         .then(({token}) => {
+          stats.tokenized = Date.now()
           const github = Github()
           github.authenticate({ type: 'token', token })
           return gen(github)
         })
         .then(response => {
+          stats.done = Date.now()
+          reportStats(stats)
           if (response.data) {
             return response.data
           }
@@ -65,6 +101,7 @@ function read (installationId, gen) {
         })
     })
   } catch (e) {
+    statsd.increment('queues.github_read_failures')
     const log = setupLog()
     log.warn('github: read exception', { installationId, exception: e })
     throw e


### PR DESCRIPTION
### Changes
- log `depName` more consistently when we bail from the transform loop
- send stats about gh queue request amount and timings to datadog
- send number of package files per dep update to datadog
- not strictly speaking in the right place: also bail from CGVB when in-range and has shrinkwrap.