### PR TITLE
feat: tag github request metrics by installationId and method

### DIFF
--- a/lib/github-queue.js
+++ b/lib/github-queue.js
@@ -36,8 +36,13 @@ function reportStats (stats) {
   statsd.gauge(`queues.github_${stats.type}_requests_time_total`, total)
 }
 
+function getGitHubMethod (gen) {
+  const [ match ] = gen.toString().match(/github\.[^(]+/)
+  return match || ''
+}
+
 function write (installationId, gen) {
-  statsd.increment('queues.github_write_requests')
+  statsd.increment('queues.github_write_requests', [installationId, getGitHubMethod(gen)])
   const stats = {
     type: 'write',
     queued: Date.now()
@@ -70,7 +75,7 @@ function write (installationId, gen) {
 }
 
 function read (installationId, gen) {
-  statsd.increment('queues.github_read_requests')
+  statsd.increment('queues.github_read_requests', [installationId, getGitHubMethod(gen)])
   const stats = {
     type: 'read',
     queued: Date.now()


### PR DESCRIPTION
This allows us to graph the amount of GitHub requests by user,
or by GitHub method (i.e. API endpoint), or both.