### PR TITLE
feat: replace global GitHub R/W queues with per-installation queues.

### DIFF
--- a/lib/github-queue.js
+++ b/lib/github-queue.js
@@ -7,8 +7,24 @@ const statsd = require('./statsd')
 const getToken = require('./get-token')
 const Github = require('../lib/github')
 
-const writeQueue = new Queue(1, Infinity)
-const readQueue = new Queue(50, Infinity)
+const readQueues = {}
+const writeQueues = {}
+
+function getWriteQueue (installationId) {
+  // requests per user should be serial
+  // hence the queue concurrency of 1
+  const writeQueue = writeQueues[installationId] || new Queue(1, Infinity)
+  writeQueue[installationId] = writeQueue
+  return writeQueue
+}
+
+function getReadQueue (installationId) {
+  // requests per user should be serial
+  // hence the queue concurrency of 1
+  const readQueue = readQueues[installationId] || new Queue(1, Infinity)
+  readQueue[installationId] = readQueue
+  return readQueue
+}
 
 module.exports = function (installationId) {
   return {
@@ -49,6 +65,7 @@ function write (installationId, gen) {
     queued: Date.now()
   }
   try {
+    const writeQueue = getWriteQueue(installationId)
     return writeQueue.add(() => {
       return Promise.delay(env.NODE_ENV === 'testing' ? 0 : 1000)
         .then(() => {
@@ -83,6 +100,7 @@ function read (installationId, gen) {
     queued: Date.now()
   }
   try {
+    const readQueue = getReadQueue(installationId)
     return readQueue.add(() => {
       stats.started = Date.now()
       return getToken(installationId)
@@ -118,9 +136,17 @@ function read (installationId, gen) {
 if (env.NODE_ENV !== 'testing') {
   setInterval(
     function collectGitHubQueueStats () {
-      statsd.gauge('queues.github-write', writeQueue.getQueueLength())
-      statsd.gauge('queues.github-read', readQueue.getQueueLength())
+      const readQueueKeys = Object.keys(readQueues)
+      const writeQueueKeys = Object.keys(writeQueues)
+      statsd.gauge('queues.github.read.queueCount', readQueueKeys.length)
+      statsd.gauge('queues.github.write.queueCount', writeQueueKeys.length)
+      readQueueKeys.forEach((installationId) => {
+        statsd.gauge('queues.github.installation.read', readQueues[installationId].length, {tag: installationId})
+      })
+      writeQueueKeys.forEach((installationId) => {
+        statsd.gauge('queues.github.installation.write', writeQueues[installationId].length, {tag: installationId})
+      })
     },
-    5000
+    1000
   )
 }


### PR DESCRIPTION
Before this change, Greenkeeper used two global queues for reading
and writing to the GitHub API. My reading of the GitHub Abuse Limit
docs[1] suggests that we replace the global queues with per-installation
queues.

Both read- and write queues are serial, e.g. include no concurrency.
In addition, write requests are delayed by 1 second.

[1]: https://developer.github.com/v3/guides/best-practices-for-integrators/#dealing-with-abuse-rate-limits

This change also introduces new metrics:
- total number of read and write queues
- number of requests per queue, tagged by installation

All metrics are reported once per second. That means we might lose some
granularity for brief blips in the read queue, but at least the
write queue stats should be mostly accurate.