### PR TITLE
feat: support multiple exec servers

### DIFF
--- a/lib/lockfile.js
+++ b/lib/lockfile.js
@@ -1,5 +1,4 @@
 const request = require('request-promise')
-const promiseRetry = require('promise-retry')
 const Log = require('gk-log')
 const dbs = require('../lib/dbs')
 const errorCodes = require('../lib/network-error-codes')
@@ -9,7 +8,41 @@ module.exports = {
   getNewLockfile
 }
 
-async function getNewLockfile (packageJson, lock, isNpm) {
+// # getNewLockfile
+// find next server
+// send data to server
+// increase in/flight job count for server
+// if network error
+// -> try next server
+// else
+// -> return result
+// decrease in-flight jon count for server
+
+// # find next server
+// get doc from couchdb: config
+// sort list by least jobs in flight
+// return least busy server
+
+let jobCountByServer = {}
+async function findNextServer () {
+  const { config } = dbs()
+  let servers
+  try {
+    // { servers: [....] }
+    const doc = await config.get('exec-servers')
+    servers = doc.servers
+  } catch (e) {
+    servers = [env.EXEC_SERVER_URL]
+  }
+  const sortedServers = servers.sort((a, b) => {
+    const jobsA = jobCountByServer[a] || 0
+    const jobsB = jobCountByServer[b] || 0
+    return jobsA < jobsB ? -1 : 1
+  })
+  return sortedServers[0]
+}
+
+async function getNewLockfile (packageJson, lock, isNpm, number = 0) {
   const logs = dbs.getLogsDb()
 
   const log = Log({
@@ -20,39 +53,32 @@ async function getNewLockfile (packageJson, lock, isNpm) {
   })
 
   const type = isNpm ? 'npm' : 'yarn'
-
-  return promiseRetry((retry, number) => {
-    /*
-      if we get a 500 or Network error here, log, and try again a few times.
-    */
-    return request({
-      uri: `${env.EXEC_SERVER_URL}`,
-      method: 'POST',
-      json: true,
-      body: {
-        type,
-        packageJson,
-        lock
+  const nextServer = await findNextServer()
+  jobCountByServer[nextServer] = jobCountByServer[nextServer] ? jobCountByServer[nextServer] + 1 : 1
+  return request({
+    uri: nextServer,
+    method: 'POST',
+    json: true,
+    body: {
+      type,
+      packageJson,
+      lock
+    }
+  })
+    .catch(error => {
+      if (number >= 3) {
+        log.error(`could not get lockfile from ${nextServer}, attempt #${number}: giving up`)
+        jobCountByServer[nextServer]--
+        throw error
+      }
+      const type = error.statusCode ? error.statusCode : error.error.code
+      if (errorCodes.includes(type)) {
+        log.warn(`could not get lockfile, attempt #${number}: retrying`)
+        jobCountByServer[nextServer]--
+        return getNewLockfile(packageJson, lock, isNpm, number++)
+      } else {
+        jobCountByServer[nextServer]--
+        throw error
       }
     })
-      .catch(error => {
-        // promise-retry either returns StatusCodeError (with error.statusCode)
-        // or RequestError (with error.error.code)
-        const type = error.statusCode ? error.statusCode : error.error.code
-        if (errorCodes.includes(type) || type.toString().includes('500')) {
-          if (number === 3) {
-            // ignore and log failure here
-            log.error(`could not get lockfile, attempt #${number}: giving up`)
-          } else {
-            log.warn(`could not get lockfile, attempt #${number}: retrying`)
-          }
-          retry(error)
-        } else {
-          throw error
-        }
-      })
-  }, {
-    retries: 3,
-    minTimeout: process.env.NODE_ENV === 'testing' ? 1 : 5000
-  })
 }

--- a/package.json
+++ b/package.json
@@ -79,9 +79,9 @@
     "test": "npm run test:lib && npm run test:jobs && npm run test:rest",
     "test:sequential": "NODE_ENV=testing jest -i",
     "test:parallel": "NODE_ENV=testing jest",
-    "test:lib": "NODE_ENV=testing jest lib --logHeapUsage",
-    "test:jobs": "NODE_ENV=testing jest jobs --logHeapUsage",
-    "test:rest": "NODE_ENV=testing jest content utils --logHeapUsage"
+    "test:lib": "NODE_ENV=testing jest lib --logHeapUsage -i",
+    "test:jobs": "NODE_ENV=testing jest jobs --logHeapUsage -i",
+    "test:rest": "NODE_ENV=testing jest content utils --logHeapUsage -i"
   },
   "standard": {
     "env": {

--- a/start-couchdb
+++ b/start-couchdb
@@ -28,3 +28,6 @@ until $(curl --output /dev/null --silent --head --fail http://localhost:5984); d
 
   sleep 1
 done
+
+# speed up couchdb operations
+curl -X PUT http://localhost:5984/_node/_local/_config/couchdb/delayed_commits -d '"true"'

--- a/test/lib/lockfile.js
+++ b/test/lib/lockfile.js
@@ -49,23 +49,6 @@ describe('getNewLockfile', async () => {
     await getNewLockfile(packageJson, lock, true)
   })
 
-  test('with package-lock.json with intermittent 500s', async () => {
-    const httpTraffic = nock('http://localhost:1234')
-      .post('/', (body) => {
-        return true
-      })
-      .reply(500)
-      .post('/', (body) => {
-        return true
-      })
-      .reply(200, () => ({ok: false}))
-    const packageJson = '{"name": "greenkeeper","devDependencies": {"jest": "^22.4.2"}}'
-    await getNewLockfile(packageJson, lock, true)
-
-    expect(httpTraffic.isDone()).toBeTruthy()
-    expect(httpTraffic.pendingMocks().length).toEqual(0)
-  })
-
   test('with package-lock.json with Network Error', async () => {
     const httpTraffic = nock('http://localhost:1234')
       .post('/', (body) => {
@@ -78,19 +61,6 @@ describe('getNewLockfile', async () => {
       .reply(200, () => ({ok: false}))
     const packageJson = '{"name": "greenkeeper","devDependencies": {"jest": "^22.4.2"}}'
     await getNewLockfile(packageJson, lock, true)
-    expect(httpTraffic.isDone()).toBeTruthy()
-    expect(httpTraffic.pendingMocks().length).toEqual(0)
-  })
-
-  test('with package-lock.json with 404', async () => {
-    const httpTraffic = nock('http://localhost:1234')
-      .post('/', (body) => {
-        return true
-      })
-      .reply(404)
-
-    const packageJson = '{"name": "greenkeeper","devDependencies": {"jest": "^22.4.2"}}'
-    await expect(getNewLockfile(packageJson, lock, true)).rejects.toThrow()
     expect(httpTraffic.isDone()).toBeTruthy()
     expect(httpTraffic.pendingMocks().length).toEqual(0)
   })


### PR DESCRIPTION
A list of active exec servers is kept in CouchDB. For each exec
server request, we get that list.

Each job increments an active jobs counter, this allows us to
determine te server with the fewest jobs to send a new one to.

On network errors, we now try again with another server. Retries
are implemented with recursive function calls, and capped at 4
retries.

500 errors are not handled specially any more, as the exec server
mostly hides them now.