### PR TITLE
fix(checks): handle check_runs too

### DIFF
--- a/jobs/github-event/check_run/completed.js
+++ b/jobs/github-event/check_run/completed.js
@@ -1,12 +1,11 @@
 /*
 
-jobs/github-event/check_suite/completed.js
+jobs/github-event/check_run/completed.js
 
-Receives webhook events for when a check suite is completed.
-Docs: https://developer.github.com/v3/activity/events/types/#checksuiteevent
+Receives webhook events for when a check run is completed.
+Docs: https://developer.github.com/v3/activity/events/types/#checkrunevent
 
-This is the handler for the`completed` action.
-
+This is the handler for the`completed` action, which according to the docs doesn’t exist for this endpoint, but according to reality actually does.
 */
 
 const _ = require('lodash')
@@ -15,7 +14,7 @@ const onBranchStatus = require('../../../lib/on-branch-status')
 module.exports = async function ({ status, conclusion, head_sha, repository, installation }) { // eslint-disable-line
   // This shouldn’t be possible, since this is the completed event handler, but hey.
   if (status !== 'completed') return
-  // The status of this particular check_suite is inconclusive (we can’t say whether the
+  // The status of this particular check_run is inconclusive (we can’t say whether the
   // build is passing or failing), so there’s no point in continuing
   if (_.includes(['cancelled', 'timed_out', 'action_required'], status)) return
   return onBranchStatus(repository, head_sha, installation)


### PR DESCRIPTION
We didn’t handle `check_runs` so far because according to the docs, they don’t have a `completed` action: 

![bildschirmfoto 2018-10-16 um 11 51 59](https://user-images.githubusercontent.com/391124/47008089-eb8c9480-d139-11e8-8131-5a8ebe205321.png)

Fun fact: they do! 👇 

![bildschirmfoto 2018-10-16 um 11 52 38](https://user-images.githubusercontent.com/391124/47008126-019a5500-d13a-11e8-8d90-ca4f8626f0d3.png)

What a shocker. So now we handle that too.

BTW: Greenkeeper still worked correctly if the `check_run` was _not_ the last check/status to arrive from github, which explains why PRs didn’t get opened only occasionally. 