### PR TITLE
fix(github): handle event payloads properly

### DIFF
--- a/jobs/github-event/check_run/completed.js
+++ b/jobs/github-event/check_run/completed.js
@@ -8,14 +8,14 @@ Docs: https://developer.github.com/v3/activity/events/types/#checkrunevent
 This is the handler for the`completed` action, which according to the docs doesn’t exist for this endpoint, but according to reality actually does.
 */
 
-const _ = require('lodash')
 const onBranchStatus = require('../../../lib/on-branch-status')
 
-module.exports = async function ({ status, conclusion, head_sha, repository, installation }) { // eslint-disable-line
+module.exports = async function ({ check_run, repository, installation }) { // eslint-disable-line
+  const { status, conclusion, head_sha } = check_run // eslint-disable-line
   // This shouldn’t be possible, since this is the completed event handler, but hey.
   if (status !== 'completed') return
   // The status of this particular check_run is inconclusive (we can’t say whether the
   // build is passing or failing), so there’s no point in continuing
-  if (_.includes(['cancelled', 'timed_out', 'action_required'], status)) return
+  if (['cancelled', 'timed_out', 'action_required'].includes(conclusion)) return
   return onBranchStatus(repository, head_sha, installation)
 }

--- a/jobs/github-event/check_suite/completed.js
+++ b/jobs/github-event/check_suite/completed.js
@@ -9,14 +9,14 @@ This is the handler for the`completed` action.
 
 */
 
-const _ = require('lodash')
 const onBranchStatus = require('../../../lib/on-branch-status')
 
-module.exports = async function ({ status, conclusion, head_sha, repository, installation }) { // eslint-disable-line
+module.exports = async function ({ check_suite, repository, installation }) { // eslint-disable-line
+  const { status, conclusion, head_sha } = check_suite // eslint-disable-line
   // This shouldn’t be possible, since this is the completed event handler, but hey.
   if (status !== 'completed') return
   // The status of this particular check_suite is inconclusive (we can’t say whether the
   // build is passing or failing), so there’s no point in continuing
-  if (_.includes(['cancelled', 'timed_out', 'action_required'], status)) return
+  if (['cancelled', 'timed_out', 'action_required'].includes(conclusion)) return
   return onBranchStatus(repository, head_sha, installation)
 }

--- a/lib/on-branch-status.js
+++ b/lib/on-branch-status.js
@@ -33,7 +33,17 @@ module.exports = async function (repository, sha, installation) {
 
   const [owner, repo] = repository.full_name.split('/')
   const accountId = String(repository.owner.id)
-  const installationId = installation.id
+  // If the event handler passes in an onstallation object, use that, otherwise, get the installationId from the db
+  // because, docs: "payloads [...] for a GitHub App's webhook may (!!!) include the installation which an event relates to"
+  // cf. https://developer.github.com/webhooks/
+  let installationId
+  if (installation) {
+    installationId = installation.id
+  } else {
+    const { installations } = await dbs()
+    const installation = await installations.get(accountId)
+    installationId = installation.installation
+  }
 
   const logs = dbs.getLogsDb()
   const log = Log({ logsDb: logs, accountId, repoSlug: repository.full_name, context: 'on-branch-status' })

--- a/lib/on-branch-status.js
+++ b/lib/on-branch-status.js
@@ -37,7 +37,7 @@ module.exports = async function (repository, sha, installation) {
   // because, docs: "payloads [...] for a GitHub App's webhook may (!!!) include the installation which an event relates to"
   // cf. https://developer.github.com/webhooks/
   let installationId
-  if (installation) {
+  if (installation && installation.id) {
     installationId = installation.id
   } else {
     const { installations } = await dbs()


### PR DESCRIPTION
Bit of a mixup with what comes from where, also handle the case that the payload may or may not include the `installation` object, but there’s no reasoning as to when or why that happens. 