### PR TITLE
fix: handle all branch state conclusions properly

### DIFF
--- a/jobs/github-event/check_run/completed.js
+++ b/jobs/github-event/check_run/completed.js
@@ -14,8 +14,5 @@ module.exports = async function ({ check_run, repository, installation }) { // e
   const { status, conclusion, head_sha } = check_run // eslint-disable-line
   // This shouldn’t be possible, since this is the completed event handler, but hey.
   if (status !== 'completed') return
-  // The status of this particular check_run is inconclusive (we can’t say whether the
-  // build is passing or failing), so there’s no point in continuing
-  if (['cancelled', 'timed_out', 'action_required'].includes(conclusion)) return
   return onBranchStatus(repository, head_sha, installation)
 }

--- a/lib/on-branch-status.js
+++ b/lib/on-branch-status.js
@@ -132,25 +132,20 @@ module.exports = async function (repository, sha, installation) {
     // If there are fewer conclusions than total runs, some are incomplete/pending
     // and we can’t continue
     if (checkRunConclusions.length !== allCheckRuns.total_count) {
-      log.warn('Bailed because check runs are incomplete', { checkRunConclusions })
+      log.warn(`Bailed because check runs are incomplete (${checkRunConclusions.length}/${allCheckRuns.total_count})`)
       return
     }
 
-    // If the collected conclusions contain `cancelled`, `timed_out`, or `action_required`, we
-    // can’t really know what to do, so we bail as well. It’s probable that the check will re-run
-    // either automatically or by user action later, and at some point all conclusions should be one of
-    // `success`, `failure`, or `neutral`, which we can work with.
-    const undesirableConclusions = ['cancelled', 'timed_out', 'action_required']
-    if (_.intersection(checkRunConclusions, undesirableConclusions).length) {
-      log.warn('Bailed due to ambiguous conclusions', { checkRunConclusions })
-      return
-    }
-    // Finally, if one of the conclusions is `failure`, we hijack the combined state and set it to `failure` too.
-    // This means that `neutral` is NOT a failure condition. We understand it as more of an `info` type
-    // message
-    if (checkRunConclusions.includes('failure')) {
+    // If all checkruns are a success or neutral, set combinedState to `success`, else `failure`
+    // This casts all failure conclusions (`cancelled`, `timed_out`, `action_required`, `failure`)
+    // as `failure`
+    const failureConclusions = ['cancelled', 'timed_out', 'action_required', 'failure']
+    if (_.intersection(checkRunConclusions, failureConclusions).length) {
       combined.state = 'failure'
+    } else {
+      combined.state = 'success'
     }
+    log.info(`Combined state set to ${combined.state}`, { checkRunConclusions })
   } else {
     log.warn('No check runs found', { allCheckRuns })
   }


### PR DESCRIPTION
If all checkruns are a success or neutral, set combinedState to `success`, else `failure`. This casts all failure conclusions (`cancelled`, `timed_out`, `action_required`, `failure`) as `failure`. Before, we ignored the first three, which led to some initial PRs not being created.