### PR TITLE
fix: get all individual statuses on branch status

### DIFF
--- a/lib/on-branch-status.js
+++ b/lib/on-branch-status.js
@@ -48,43 +48,37 @@ module.exports = async function (repository, sha, installation) {
   const logs = dbs.getLogsDb()
   const log = Log({ logsDb: logs, accountId, repoSlug: repository.full_name, context: 'on-branch-status' })
   log.info('Received branch status')
-  /* 1. Get combined state of all statuses for this branch
-  https://developer.github.com/v3/repos/statuses/#get-the-combined-status-for-a-specific-ref
-
-  `combined.state` is one of:
-
-  - `failure` if any of the contexts report as `error` or `failure`
-  - `pending` if there are no statuses or a context is `pending`
-  - `success` if the latest status for all contexts is `success`
-
-  Note that there may be no statuses, only checks, in this case, GitHub returns:
-
-  "state": "pending",
-  "statuses": [],
-  …
-
-  Since `status.js` only calls this code if the state is one of 'success', 'failure', 'error', we can be certain
-  that it’s actually _not_ pending, but that there are no statuses at all.
+  /* 1. Get all statuses for this branch
+  https://developer.github.com/v3/repos/statuses/#list-statuses-for-a-specific-ref
+  (getStatuses) in our version of Octokit
   */
-  const combined = await GithubQueue(installationId).read(github => github.repos.getCombinedStatusForRef({
+  let combined = {
+    statuses: [],
+    state: undefined
+  }
+  combined.statuses = await GithubQueue(installationId).read(github => github.repos.getStatuses({
     owner,
     repo,
     ref: sha
   }))
-  log.info('Got combined status for branch', { combined })
-  if (combined.state === 'pending' && combined.statuses.length === 0) {
-    combined.state = 'success'
-    log.info('No statuses found, continue to checks')
-    // this is fine, this means that there are no statuses on the repo at all, but there
-    // should be checks (otherwise we wouldn’t be in this file)
-  } else {
-    // We _do_ continue on failure since the `handleBranchStatus` job can also
-    // comment with notifications about failing builds.
-    if (!_.includes(['success', 'failure'], combined.state)) {
-      log.info('exited: build state is neither success nor failure ', { state: combined.state })
+
+  if (combined.statuses.length > 0) {
+    const hasPendingStatuses = combined.statuses.find(status => status.state === 'pending')
+    if (hasPendingStatuses) {
+      log.warn('Has pending statuses, bailing.', { combined })
       return
     }
+    const hasFailingStatuses = combined.statuses.find(status => status.state === 'failure' || status.state === 'error')
+    if (hasFailingStatuses) {
+      combined.state = 'failure'
+    } else {
+      combined.state = 'success'
+    }
+    log.info(`After all statuses completed, combined state set to ${combined.state}`, { combined })
+  } else {
+    log.info('No statuses, continuing with checks.')
   }
+
   /* 2. Get the combined Checks for this branch
 
   Takes the same args as the previous GitHub call, but fetches all checks for the ref. Returns an
@@ -131,6 +125,8 @@ module.exports = async function (repository, sha, installation) {
 
     // If there are fewer conclusions than total runs, some are incomplete/pending
     // and we can’t continue
+    // ⚠️  allCheckRuns.total_count IS NOT necessarily the total count of all check runs! It’s the total count
+    // at this moment in time.
     if (checkRunConclusions.length !== allCheckRuns.total_count) {
       log.warn(`Bailed because check runs are incomplete (${checkRunConclusions.length}/${allCheckRuns.total_count})`)
       return
@@ -140,7 +136,8 @@ module.exports = async function (repository, sha, installation) {
     // This casts all failure conclusions (`cancelled`, `timed_out`, `action_required`, `failure`)
     // as `failure`
     const failureConclusions = ['cancelled', 'timed_out', 'action_required', 'failure']
-    if (_.intersection(checkRunConclusions, failureConclusions).length) {
+    const hasFailureConclusions = !!_.intersection(checkRunConclusions, failureConclusions).length
+    if (hasFailureConclusions) {
       combined.state = 'failure'
     } else {
       combined.state = 'success'

--- a/test/jobs/github-event/check_suite/completed.js
+++ b/test/jobs/github-event/check_suite/completed.js
@@ -24,14 +24,18 @@ describe('github-event checksuite_completed', async () => {
     const { repositories, installations } = await dbs()
     await Promise.all([
       removeIfExists(installations, '1111'),
-      removeIfExists(repositories, '42:branch:deadbeef')
+      removeIfExists(repositories, '42:branch:deadbeef'),
+      removeIfExists(repositories, '42:branch:catbus'),
+      removeIfExists(repositories, '42:branch:busdog'),
+      removeIfExists(repositories, '42:branch:pelicanballoon'),
+      removeIfExists(repositories, '42:branch:giraffeplane')
     ])
   })
 
   test('initial pr, no statuses', async () => {
     const { repositories } = await dbs()
     expect.assertions(6)
-    const githubStatus = require('../../../../jobs/github-event/status')
+    const checkrunCompleted = require('../../../../jobs/github-event/check_run/completed')
 
     nock('https://api.github.com')
       .post('/app/installations/7331/access_tokens')
@@ -42,11 +46,8 @@ describe('github-event checksuite_completed', async () => {
       .get('/rate_limit')
       .optionally()
       .reply(200, {})
-      .get('/repos/club/mate/commits/deadbeef/status')
-      .reply(200, {
-        state: 'pending',
-        statuses: []
-      })
+      .get('/repos/club/mate/commits/deadbeef/statuses')
+      .reply(200, [])
       .get('/repos/club/mate/commits/deadbeef/check-runs')
       .reply(200, {
         'total_count': 2,
@@ -82,9 +83,12 @@ describe('github-event checksuite_completed', async () => {
       sha: 'deadbeef'
     })
 
-    const newJob = await githubStatus({
-      state: 'success',
-      sha: 'deadbeef',
+    const newJob = await checkrunCompleted({
+      check_run: {
+        'head_sha': 'deadbeef',
+        'status': 'completed',
+        'conclusion': 'success'
+      },
       installation: { id: 7331 },
       repository: {
         id: 42,
@@ -107,7 +111,7 @@ describe('github-event checksuite_completed', async () => {
   test('no initial pr, no statuses, one check pending', async () => {
     const { repositories } = await dbs()
     expect.assertions(1)
-    const githubStatus = require('../../../../jobs/github-event/status')
+    const checkrunCompleted = require('../../../../jobs/github-event/check_run/completed')
 
     nock('https://api.github.com')
       .post('/app/installations/7331/access_tokens')
@@ -118,11 +122,8 @@ describe('github-event checksuite_completed', async () => {
       .get('/rate_limit')
       .optionally()
       .reply(200, {})
-      .get('/repos/club/mate/commits/catbus/status')
-      .reply(200, {
-        state: 'pending',
-        statuses: []
-      })
+      .get('/repos/club/mate/commits/catbus/statuses')
+      .reply(200, [])
       .get('/repos/club/mate/commits/catbus/check-runs')
       .reply(200, {
         'total_count': 2,
@@ -157,9 +158,12 @@ describe('github-event checksuite_completed', async () => {
       sha: 'catbus'
     })
 
-    const newJob = await githubStatus({
-      state: 'success',
-      sha: 'catbus',
+    const newJob = await checkrunCompleted({
+      check_run: {
+        'head_sha': 'catbus',
+        'status': 'completed',
+        'conclusion': 'success'
+      },
       installation: { id: 7331 },
       repository: {
         id: 42,
@@ -171,5 +175,274 @@ describe('github-event checksuite_completed', async () => {
     })
 
     expect(newJob).toBeFalsy()
+  })
+
+  test('no initial pr, one successful status, one check pending', async () => {
+    const { repositories } = await dbs()
+    expect.assertions(1)
+    const githubStatus = require('../../../../jobs/github-event/status')
+
+    nock('https://api.github.com')
+      .post('/app/installations/7331/access_tokens')
+      .optionally()
+      .reply(200, {
+        token: 'secret'
+      })
+      .get('/rate_limit')
+      .optionally()
+      .reply(200, {})
+      .get('/repos/club/mate/commits/busdog/statuses')
+      .reply(200, [
+        {
+          'url': 'https://api.github.com/repos/octocat/Hello-World/statuses/6dcb09b5b57875f334f61aebed695e2e4193db5e',
+          'avatar_url': 'https://github.com/images/error/hubot_happy.gif',
+          'id': 1,
+          'node_id': 'MDY6U3RhdHVzMQ==',
+          'state': 'success',
+          'description': 'Build has completed successfully',
+          'target_url': 'https://ci.example.com/1000/output',
+          'context': 'continuous-integration/jenkins',
+          'created_at': '2012-07-20T01:19:13Z',
+          'updated_at': '2012-07-20T01:19:13Z',
+          'creator': {
+            'login': 'octocat',
+            'id': 1,
+            'node_id': 'MDQ6VXNlcjE=',
+            'avatar_url': 'https://github.com/images/error/octocat_happy.gif',
+            'gravatar_id': '',
+            'url': 'https://api.github.com/users/octocat',
+            'html_url': 'https://github.com/octocat',
+            'followers_url': 'https://api.github.com/users/octocat/followers',
+            'following_url': 'https://api.github.com/users/octocat/following{/other_user}',
+            'gists_url': 'https://api.github.com/users/octocat/gists{/gist_id}',
+            'starred_url': 'https://api.github.com/users/octocat/starred{/owner}{/repo}',
+            'subscriptions_url': 'https://api.github.com/users/octocat/subscriptions',
+            'organizations_url': 'https://api.github.com/users/octocat/orgs',
+            'repos_url': 'https://api.github.com/users/octocat/repos',
+            'events_url': 'https://api.github.com/users/octocat/events{/privacy}',
+            'received_events_url': 'https://api.github.com/users/octocat/received_events',
+            'type': 'User',
+            'site_admin': false
+          }
+        }
+      ])
+      .get('/repos/club/mate/commits/busdog/check-runs')
+      .reply(200, {
+        'total_count': 2,
+        'check_runs': [
+          {
+            'id': 5599907,
+            'head_sha': '9e6e440a0e6413b4c17eacd7f8bcd81343cc200a',
+            'status': 'completed',
+            'conclusion': 'success',
+            'output': {
+              'title': 'Build Passed',
+              'summary': '<a href="https://travis-ci.com/club/mate/builds/77480025"><img src="https://travis-ci.com/images/stroke-icons/icon-passed.png" height="11"> The build</a> **passed**.'
+            },
+            'name': 'Travis CI - Branch'
+          },
+          {
+            'id': 5473198,
+            'head_sha': '9e6e440a0e6413b4c17eacd7f8bcd81343cc200a',
+            'status': 'in_progress',
+            'output': {
+              'summary': '<a href="https://travis-ci.com/club/mate/builds/77480041"><img src="https://travis-ci.com/images/stroke-icons/icon-passed.png" height="11"> The build</a> **passed**, just like the previous build.'
+            },
+            'name': 'Travis CI - Pull Request'
+          }
+        ]
+      })
+
+    await repositories.put({
+      _id: '42:branch:busdog',
+      type: 'branch',
+      initial: true,
+      sha: 'busdog'
+    })
+
+    const newJob = await githubStatus({
+      state: 'success',
+      sha: 'busdog',
+      installation: { id: 7331 },
+      repository: {
+        id: 42,
+        full_name: 'club/mate',
+        owner: {
+          id: 1111
+        }
+      }
+    })
+
+    expect(newJob).toBeFalsy()
+  })
+
+  test('no initial pr, no statuses, one check pending', async () => {
+    const { repositories } = await dbs()
+    expect.assertions(1)
+    const githubStatus = require('../../../../jobs/github-event/status')
+
+    nock('https://api.github.com')
+      .post('/app/installations/7331/access_tokens')
+      .optionally()
+      .reply(200, {
+        token: 'secret'
+      })
+      .get('/rate_limit')
+      .optionally()
+      .reply(200, {})
+      .get('/repos/club/mate/commits/pelicanballoon/statuses')
+      .reply(200, [])
+      .get('/repos/club/mate/commits/pelicanballoon/check-runs')
+      .reply(200, {
+        'total_count': 2,
+        'check_runs': [
+          {
+            'id': 5599907,
+            'head_sha': '9e6e440a0e6413b4c17eacd7f8bcd81343cc200a',
+            'status': 'completed',
+            'conclusion': 'success',
+            'output': {
+              'title': 'Build Passed',
+              'summary': '<a href="https://travis-ci.com/club/mate/builds/77480025"><img src="https://travis-ci.com/images/stroke-icons/icon-passed.png" height="11"> The build</a> **passed**.'
+            },
+            'name': 'Travis CI - Branch'
+          },
+          {
+            'id': 5473198,
+            'head_sha': '9e6e440a0e6413b4c17eacd7f8bcd81343cc200a',
+            'status': 'in_progress',
+            'output': {
+              'summary': '<a href="https://travis-ci.com/club/mate/builds/77480041"><img src="https://travis-ci.com/images/stroke-icons/icon-passed.png" height="11"> The build</a> **passed**, just like the previous build.'
+            },
+            'name': 'Travis CI - Pull Request'
+          }
+        ]
+      })
+
+    await repositories.put({
+      _id: '42:branch:pelicanballoon',
+      type: 'branch',
+      initial: true,
+      sha: 'pelicanballoon'
+    })
+
+    const newJob = await githubStatus({
+      state: 'success',
+      sha: 'pelicanballoon',
+      installation: { id: 7331 },
+      repository: {
+        id: 42,
+        full_name: 'club/mate',
+        owner: {
+          id: 1111
+        }
+      }
+    })
+
+    expect(newJob).toBeFalsy()
+  })
+
+  test('no initial pr, one successful status, two successful checks', async () => {
+    const { repositories } = await dbs()
+    expect.assertions(4)
+    const githubStatus = require('../../../../jobs/github-event/status')
+
+    nock('https://api.github.com')
+      .post('/app/installations/7331/access_tokens')
+      .optionally()
+      .reply(200, {
+        token: 'secret'
+      })
+      .get('/rate_limit')
+      .optionally()
+      .reply(200, {})
+      .get('/repos/club/mate/commits/giraffeplane/statuses')
+      .reply(200, [
+        {
+          'url': 'https://api.github.com/repos/octocat/Hello-World/statuses/6dcb09b5b57875f334f61aebed695e2e4193db5e',
+          'avatar_url': 'https://github.com/images/error/hubot_happy.gif',
+          'id': 1,
+          'node_id': 'MDY6U3RhdHVzMQ==',
+          'state': 'success',
+          'description': 'Build has completed successfully',
+          'target_url': 'https://ci.example.com/1000/output',
+          'context': 'continuous-integration/jenkins',
+          'created_at': '2012-07-20T01:19:13Z',
+          'updated_at': '2012-07-20T01:19:13Z',
+          'creator': {
+            'login': 'octocat',
+            'id': 1,
+            'node_id': 'MDQ6VXNlcjE=',
+            'avatar_url': 'https://github.com/images/error/octocat_happy.gif',
+            'gravatar_id': '',
+            'url': 'https://api.github.com/users/octocat',
+            'html_url': 'https://github.com/octocat',
+            'followers_url': 'https://api.github.com/users/octocat/followers',
+            'following_url': 'https://api.github.com/users/octocat/following{/other_user}',
+            'gists_url': 'https://api.github.com/users/octocat/gists{/gist_id}',
+            'starred_url': 'https://api.github.com/users/octocat/starred{/owner}{/repo}',
+            'subscriptions_url': 'https://api.github.com/users/octocat/subscriptions',
+            'organizations_url': 'https://api.github.com/users/octocat/orgs',
+            'repos_url': 'https://api.github.com/users/octocat/repos',
+            'events_url': 'https://api.github.com/users/octocat/events{/privacy}',
+            'received_events_url': 'https://api.github.com/users/octocat/received_events',
+            'type': 'User',
+            'site_admin': false
+          }
+        }
+      ])
+      .get('/repos/club/mate/commits/giraffeplane/check-runs')
+      .reply(200, {
+        'total_count': 2,
+        'check_runs': [
+          {
+            'id': 5599907,
+            'head_sha': '9e6e440a0e6413b4c17eacd7f8bcd81343cc200a',
+            'status': 'completed',
+            'conclusion': 'success',
+            'output': {
+              'title': 'Build Passed',
+              'summary': '<a href="https://travis-ci.com/club/mate/builds/77480025"><img src="https://travis-ci.com/images/stroke-icons/icon-passed.png" height="11"> The build</a> **passed**.'
+            },
+            'name': 'Travis CI - Branch'
+          },
+          {
+            'id': 5473198,
+            'head_sha': '9e6e440a0e6413b4c17eacd7f8bcd81343cc200a',
+            'status': 'completed',
+            'conclusion': 'success',
+            'output': {
+              'summary': '<a href="https://travis-ci.com/club/mate/builds/77480041"><img src="https://travis-ci.com/images/stroke-icons/icon-passed.png" height="11"> The build</a> **passed**, just like the previous build.'
+            },
+            'name': 'Travis CI - Pull Request'
+          }
+        ]
+      })
+
+    await repositories.put({
+      _id: '42:branch:giraffeplane',
+      type: 'branch',
+      initial: true,
+      sha: 'giraffeplane'
+    })
+
+    const newJob = await githubStatus({
+      state: 'success',
+      sha: 'giraffeplane',
+      installation: { id: 7331 },
+      repository: {
+        id: 42,
+        full_name: 'club/mate',
+        owner: {
+          id: 1111
+        }
+      }
+    })
+
+    expect(newJob).toBeTruthy()
+    expect(newJob.data.combined.state).toEqual('success')
+    // Checks are also added to the combined.statuses array, so 2 checks + 1 status = 3
+    expect(newJob.data.combined.statuses).toHaveLength(3)
+    expect(newJob.data.name).toEqual('create-initial-pr')
   })
 })

--- a/test/jobs/github-event/status.js
+++ b/test/jobs/github-event/status.js
@@ -28,7 +28,7 @@ describe('github-event status', async () => {
     ])
   })
 
-  test('initial pr', async () => {
+  test('initial pr with 1 successful status', async () => {
     const { repositories } = await dbs()
     expect.assertions(6)
     const githubStatus = require('../../../jobs/github-event/status')
@@ -42,11 +42,12 @@ describe('github-event status', async () => {
       .get('/rate_limit')
       .optionally()
       .reply(200, {})
-      .get('/repos/club/mate/commits/deadbeef/status')
-      .reply(200, {
-        state: 'success',
-        statuses: []
-      })
+      .get('/repos/club/mate/commits/deadbeef/statuses')
+      .reply(200, [{
+        'state': 'success',
+        'description': 'Build has completed successfully',
+        'context': 'continuous-integration/jenkins'
+      }])
       .get('/repos/club/mate/commits/deadbeef/check-runs')
       .reply(200, {
         'total_count': 0,
@@ -82,7 +83,7 @@ describe('github-event status', async () => {
     expect(job.installationId).toEqual(1336)
   })
 
-  test('initial pr with checks', async () => {
+  test('initial pr with 2 checks, 1 status', async () => {
     const { repositories } = await dbs()
     expect.assertions(7)
     const githubStatus = require('../../../jobs/github-event/status')
@@ -96,11 +97,12 @@ describe('github-event status', async () => {
       .get('/rate_limit')
       .optionally()
       .reply(200, {})
-      .get('/repos/club/mate/commits/muppets/status')
-      .reply(200, {
-        state: 'success',
-        statuses: []
-      })
+      .get('/repos/club/mate/commits/muppets/statuses')
+      .reply(200, [{
+        'state': 'success',
+        'description': 'Build has completed successfully',
+        'context': 'continuous-integration/jenkins'
+      }])
       .get('/repos/club/mate/commits/muppets/check-runs')
       .reply(200, {
         'total_count': 2,
@@ -156,10 +158,10 @@ describe('github-event status', async () => {
     expect(job.combined.state).toEqual('success')
     expect(job.repository.id).toBe(42)
     expect(job.installationId).toEqual(1336)
-    expect(job.combined.statuses).toHaveLength(2)
+    expect(job.combined.statuses).toHaveLength(3)
   })
 
-  test('initial pr fails with a failed check', async () => {
+  test('initial pr fails with a failed check, two successful statuses', async () => {
     const { repositories } = await dbs()
     expect.assertions(7)
     const githubStatus = require('../../../jobs/github-event/status')
@@ -173,11 +175,16 @@ describe('github-event status', async () => {
       .get('/rate_limit')
       .optionally()
       .reply(200, {})
-      .get('/repos/club/mate/commits/hats/status')
-      .reply(200, {
-        state: 'success',
-        statuses: [{ 'state': 'success' }, { 'state': 'success' }]
-      })
+      .get('/repos/club/mate/commits/hats/statuses')
+      .reply(200, [{
+        'state': 'success',
+        'description': 'Build has completed successfully',
+        'context': 'continuous-integration/jenkins'
+      }, {
+        'state': 'success',
+        'description': 'PR is verified',
+        'context': 'greenkeeper/verify'
+      }])
       .get('/repos/club/mate/commits/hats/check-runs')
       .reply(200, {
         'total_count': 2,
@@ -235,7 +242,8 @@ describe('github-event status', async () => {
     expect(job.installationId).toEqual(1336)
     expect(job.combined.statuses).toHaveLength(4)
   })
-  test('initial pr by user', async () => {
+
+  test('initial pr by user, 1 status, no checks', async () => {
     const { repositories } = await dbs()
     expect.assertions(8)
 
@@ -250,11 +258,12 @@ describe('github-event status', async () => {
       .get('/rate_limit')
       .optionally()
       .reply(200, {})
-      .get('/repos/club/mate/commits/deadbeef/status')
-      .reply(200, {
-        state: 'success',
-        statuses: []
-      })
+      .get('/repos/club/mate/commits/deadbeef/statuses')
+      .reply(200, [{
+        'state': 'success',
+        'description': 'Build has completed successfully',
+        'context': 'continuous-integration/jenkins'
+      }])
       .get('/repos/club/mate/commits/deadbeef/check-runs')
       .reply(200, {
         'total_count': 0,
@@ -300,7 +309,7 @@ describe('github-event status', async () => {
     expect(job.installationId).toEqual(1336)
   })
 
-  test('initial subgroup pr', async () => {
+  test('initial subgroup pr, 1 status, no checks', async () => {
     const { repositories } = await dbs()
     expect.assertions(7)
     const githubStatus = require('../../../jobs/github-event/status')
@@ -314,11 +323,12 @@ describe('github-event status', async () => {
       .get('/rate_limit')
       .optionally()
       .reply(200, {})
-      .get('/repos/lara/monorepo/commits/abcdf1234/status')
-      .reply(200, {
-        state: 'success',
-        statuses: []
-      })
+      .get('/repos/lara/monorepo/commits/abcdf1234/statuses')
+      .reply(200, [{
+        'state': 'success',
+        'description': 'Build has completed successfully',
+        'context': 'continuous-integration/jenkins'
+      }])
       .get('/repos/lara/monorepo/commits/abcdf1234/check-runs')
       .reply(200, {
         'total_count': 0,
@@ -360,7 +370,7 @@ describe('github-event status', async () => {
     expect(job.groupName).toEqual('frontend')
   })
 
-  test('initial subgroup pr by user', async () => {
+  test('initial subgroup pr by user, 1 status, no checks', async () => {
     const { repositories } = await dbs()
     expect.assertions(9)
 
@@ -375,11 +385,12 @@ describe('github-event status', async () => {
       .get('/rate_limit')
       .optionally()
       .reply(200, {})
-      .get('/repos/plant/monorepo/commits/plantsarethebest11/status')
-      .reply(200, {
-        state: 'success',
-        statuses: []
-      })
+      .get('/repos/plant/monorepo/commits/plantsarethebest11/statuses')
+      .reply(200, [{
+        'state': 'success',
+        'description': 'Build has completed successfully',
+        'context': 'continuous-integration/jenkins'
+      }])
       .get('/repos/plant/monorepo/commits/plantsarethebest11/check-runs')
       .reply(200, {
         'total_count': 0,
@@ -431,7 +442,7 @@ describe('github-event status', async () => {
     expect(job.groupName).toEqual('frontend')
   })
 
-  test('version branch', async () => {
+  test('version branch, 1 status, no checks', async () => {
     const { repositories } = await dbs()
     expect.assertions(6)
 
@@ -453,11 +464,12 @@ describe('github-event status', async () => {
       .get('/rate_limit')
       .optionally()
       .reply(200, {})
-      .get('/repos/club/mate/commits/deadbeef2/status')
-      .reply(200, {
-        state: 'success',
-        statuses: []
-      })
+      .get('/repos/club/mate/commits/deadbeef2/statuses')
+      .reply(200, [{
+        'state': 'success',
+        'description': 'Build has completed successfully',
+        'context': 'continuous-integration/jenkins'
+      }])
       .get('/repos/club/mate/commits/deadbeef2/check-runs')
       .reply(200, {
         'total_count': 0,
@@ -511,11 +523,12 @@ describe('github-event status', async () => {
       .get('/rate_limit')
       .optionally()
       .reply(200, {})
-      .get('/repos/club/mate/commits/gnu2/status')
-      .reply(200, {
-        state: 'success',
-        statuses: []
-      })
+      .get('/repos/club/mate/commits/gnu2/statuses')
+      .reply(200, [{
+        'state': 'success',
+        'description': 'Build has completed successfully',
+        'context': 'continuous-integration/jenkins'
+      }])
       .get('/repos/club/mate/commits/gnu2/check-runs')
       .reply(403, {
         'message': 'Resource not accessible by integration',


### PR DESCRIPTION
Since `getCombinedStatusForRef` doesn’t tell us how many statuses we should be waiting for, we now use `List statuses for a specific ref` instead.