### PR TITLE
Fix/get all statuses

### DIFF
--- a/content/initial-pr.js
+++ b/content/initial-pr.js
@@ -22,27 +22,27 @@ This step only needs to be run once per Greenkeeper _installation_, meaning once
 - These commands can be run on your local machine
 - You must be authenticated for the npm registry in the terminal session you’re using (see [npm login](https://docs.npmjs.com/creating-a-new-npm-user-account#testing-your-new-account-with-npm-login))
 - This is a one-time operation, once you’ve registered the hook with npm, Greenkeeper will get updates until you tell npm to stop sending them, or you uninstall Greenkeeper on your org or user account.
-- Make sure you replace the placeholders below with the actual values you need:
+- ⚠️ Make sure you replace the placeholders below with the actual values you need:
   - \`SCOPED_PACKAGE_NAME\`: A full scoped package name, such as \`@megacorp/widget\`
   - \`SCOPE_NAME\`: Just the scope name: \`@megacorp\`
   - \`OWNER_NAME\`: An npm username: \`substack\`
 
 \`\`\`bash
-# First, install npm's wombat CLI to be able to create npm hooks
-npm install --global wombat
-
-# Some of the things you can do now:
+# Some of the things you can do with npm hooks:
 # Add a single private scoped package
-wombat hook add SCOPED_PACKAGE_NAME https://${env.HOOKS_HOST}/npm/${installationId} ${secret}
+npm hook add SCOPED_PACKAGE_NAME https://${env.HOOKS_HOST}/npm/${installationId} ${secret}
 
 # Add all private packages in a scope
-wombat hook add SCOPE_NAME https://${env.HOOKS_HOST}/npm/${installationId} ${secret}
+npm hook add SCOPE_NAME https://${env.HOOKS_HOST}/npm/${installationId} ${secret}
 
 # Add all private packages by a specific owner
-wombat hook add --type owner OWNER_NAME https://${env.HOOKS_HOST}/npm/${installationId} ${secret}
+npm hook add --type owner OWNER_NAME https://${env.HOOKS_HOST}/npm/${installationId} ${secret}
 \`\`\`
 
-For additional options and information, please consult the [Wombat docs](https://www.npmjs.com/package/wombat).
+For additional options and information, please consult the [npm CLI docs](
+https://docs.npmjs.com/cli/hook.html).
+
+If you are using npm version 5 or below, you need a separate tool called wombat to do this. Globally install wombat via npm and then use the same commands as above, but with \`wombat\` instead of \`npm\`. More in the [Wombat docs](https://www.npmjs.com/package/wombat).
 `
 
 const badgeAddedText = ({ badgeUrl }) => md`
@@ -184,6 +184,7 @@ const mainMessage = ({ enabled, depsUpdated, groupName }) => {
   if (groupName && depsUpdated) return md`This pull request **updates all your dependencies in the group \`${groupName}\` to their latest version**. Having them all up to date really is the best starting point for keeping up with new releases. As long as you have the group defined in your \`greenkeeper.json\`, Greenkeeper will look out for further dependency updates relevant to this group and make sure to always handle them together and in real-time.`
   if (enabled) return 'All of your dependencies are already up-to-date, so this repository was enabled right away. Good job :thumbsup:'
   if (depsUpdated) return 'This pull request **updates all your dependencies to their latest version**. Having them all up to date really is the best starting point for keeping up with new releases. Greenkeeper will look out for further dependency updates and make sure to handle them in isolation and in real-time, but only after **you merge this pull request**.'
+  if (!enabled && !depsUpdated) return 'This pull request only adds the Greenkeeper badge to your readme file, since all of the dependencies were already up to date. Greenkeeper will look out for further dependency updates and make sure to handle them in isolation and in real-time, but only after **you merge this pull request**.'
   return '' // no updates, but private repository
 }
 

--- a/lib/on-branch-status.js
+++ b/lib/on-branch-status.js
@@ -33,7 +33,7 @@ module.exports = async function (repository, sha, installation) {
 
   const [owner, repo] = repository.full_name.split('/')
   const accountId = String(repository.owner.id)
-  // If the event handler passes in an onstallation object, use that, otherwise, get the installationId from the db
+  // If the event handler passes in an installation object, use that, otherwise, get the installationId from the db
   // because, docs: "payloads [...] for a GitHub App's webhook may (!!!) include the installation which an event relates to"
   // cf. https://developer.github.com/webhooks/
   let installationId
@@ -51,6 +51,9 @@ module.exports = async function (repository, sha, installation) {
   /* 1. Get all statuses for this branch
   https://developer.github.com/v3/repos/statuses/#list-statuses-for-a-specific-ref
   (getStatuses) in our version of Octokit
+
+  This `combined` object echoes the combined state from https://developer.github.com/v3/repos/statuses/#get-the-combined-status-for-a-specific-ref, but we use it to generate a state that takes both statuses AND checks into account, whereas the original only handles statuses.
+
   */
   let combined = {
     statuses: [],
@@ -125,8 +128,6 @@ module.exports = async function (repository, sha, installation) {
 
     // If there are fewer conclusions than total runs, some are incomplete/pending
     // and we can’t continue
-    // ⚠️  allCheckRuns.total_count IS NOT necessarily the total count of all check runs! It’s the total count
-    // at this moment in time.
     if (checkRunConclusions.length !== allCheckRuns.total_count) {
       log.warn(`Bailed because check runs are incomplete (${checkRunConclusions.length}/${allCheckRuns.total_count})`)
       return

--- a/package.json
+++ b/package.json
@@ -76,11 +76,12 @@
     "deploy": "./deploy",
     "pretest": "standard && npm run db:start",
     "start": "node index.js",
-    "test": "npm run test:lib && npm run test:jobs && npm run test:rest",
+    "test": "npm run test:lib && npm run test:jobs && npm run test:github && npm run test:rest",
     "test:sequential": "NODE_ENV=testing jest -i",
     "test:parallel": "NODE_ENV=testing jest",
     "test:lib": "NODE_ENV=testing jest lib --logHeapUsage -i",
-    "test:jobs": "NODE_ENV=testing jest jobs --logHeapUsage -i",
+    "test:jobs": "NODE_ENV=testing jest jobs/* --logHeapUsage -i",
+    "test:github": "NODE_ENV=testing jest github-event --logHeapUsage -i",
     "test:rest": "NODE_ENV=testing jest content utils --logHeapUsage -i"
   },
   "standard": {

--- a/package.json
+++ b/package.json
@@ -76,12 +76,14 @@
     "deploy": "./deploy",
     "pretest": "standard && npm run db:start",
     "start": "node index.js",
-    "test": "npm run test:lib && npm run test:jobs && npm run test:github && npm run test:rest",
+    "test": "npm run test:chunked",
+    "test:localdb": "COUCH_URL=http://localhost:5984 standard && npm run test:chunked",
+    "test:chunked": "npm run test:lib && npm run test:jobs && npm run test:github && npm run test:rest",
     "test:sequential": "NODE_ENV=testing jest -i",
     "test:parallel": "NODE_ENV=testing jest",
     "test:lib": "NODE_ENV=testing jest lib --logHeapUsage -i",
-    "test:jobs": "NODE_ENV=testing jest jobs/* --logHeapUsage -i",
-    "test:github": "NODE_ENV=testing jest github-event --logHeapUsage -i",
+    "test:jobs": "NODE_ENV=testing jest jobs/*.js --logHeapUsage -i",
+    "test:github": "NODE_ENV=testing jest jobs/github-event --logHeapUsage -i",
     "test:rest": "NODE_ENV=testing jest content utils --logHeapUsage -i"
   },
   "standard": {

--- a/test/jobs/__snapshots__/create-initial-pr.js.snap
+++ b/test/jobs/__snapshots__/create-initial-pr.js.snap
@@ -605,27 +605,27 @@ This step only needs to be run once per Greenkeeper _installation_, meaning once
 - These commands can be run on your local machine
 - You must be authenticated for the npm registry in the terminal session you’re using (see [npm login](https://docs.npmjs.com/creating-a-new-npm-user-account#testing-your-new-account-with-npm-login))
 - This is a one-time operation, once you’ve registered the hook with npm, Greenkeeper will get updates until you tell npm to stop sending them, or you uninstall Greenkeeper on your org or user account.
-- Make sure you replace the placeholders below with the actual values you need:
+- ⚠️ Make sure you replace the placeholders below with the actual values you need:
   - \`SCOPED_PACKAGE_NAME\`: A full scoped package name, such as \`@megacorp/widget\`
   - \`SCOPE_NAME\`: Just the scope name: \`@megacorp\`
   - \`OWNER_NAME\`: An npm username: \`substack\`
 
 \`\`\`bash
-# First, install npm's wombat CLI to be able to create npm hooks
-npm install --global wombat
-
-# Some of the things you can do now:
+# Some of the things you can do with npm hooks:
 # Add a single private scoped package
-wombat hook add SCOPED_PACKAGE_NAME https://hooks.greenkeeper.io/npm/11 84123bd5fcf22427242d3038f73e40d1a51fc18081e90c8a1e6d3c5485690edd
+npm hook add SCOPED_PACKAGE_NAME https://hooks.greenkeeper.io/npm/11 84123bd5fcf22427242d3038f73e40d1a51fc18081e90c8a1e6d3c5485690edd
 
 # Add all private packages in a scope
-wombat hook add SCOPE_NAME https://hooks.greenkeeper.io/npm/11 84123bd5fcf22427242d3038f73e40d1a51fc18081e90c8a1e6d3c5485690edd
+npm hook add SCOPE_NAME https://hooks.greenkeeper.io/npm/11 84123bd5fcf22427242d3038f73e40d1a51fc18081e90c8a1e6d3c5485690edd
 
 # Add all private packages by a specific owner
-wombat hook add --type owner OWNER_NAME https://hooks.greenkeeper.io/npm/11 84123bd5fcf22427242d3038f73e40d1a51fc18081e90c8a1e6d3c5485690edd
+npm hook add --type owner OWNER_NAME https://hooks.greenkeeper.io/npm/11 84123bd5fcf22427242d3038f73e40d1a51fc18081e90c8a1e6d3c5485690edd
 \`\`\`
 
-For additional options and information, please consult the [Wombat docs](https://www.npmjs.com/package/wombat).
+For additional options and information, please consult the [npm CLI docs](
+https://docs.npmjs.com/cli/hook.html).
+
+If you are using npm version 5 or below, you need a separate tool called wombat to do this. Globally install wombat via npm and then use the same commands as above, but with \`wombat\` instead of \`npm\`. More in the [Wombat docs](https://www.npmjs.com/package/wombat).
 </details>
 <details>
 <summary>🙈 How to ignore certain dependencies</summary>
@@ -733,27 +733,27 @@ This step only needs to be run once per Greenkeeper _installation_, meaning once
 - These commands can be run on your local machine
 - You must be authenticated for the npm registry in the terminal session you’re using (see [npm login](https://docs.npmjs.com/creating-a-new-npm-user-account#testing-your-new-account-with-npm-login))
 - This is a one-time operation, once you’ve registered the hook with npm, Greenkeeper will get updates until you tell npm to stop sending them, or you uninstall Greenkeeper on your org or user account.
-- Make sure you replace the placeholders below with the actual values you need:
+- ⚠️ Make sure you replace the placeholders below with the actual values you need:
   - \`SCOPED_PACKAGE_NAME\`: A full scoped package name, such as \`@megacorp/widget\`
   - \`SCOPE_NAME\`: Just the scope name: \`@megacorp\`
   - \`OWNER_NAME\`: An npm username: \`substack\`
 
 \`\`\`bash
-# First, install npm's wombat CLI to be able to create npm hooks
-npm install --global wombat
-
-# Some of the things you can do now:
+# Some of the things you can do with npm hooks:
 # Add a single private scoped package
-wombat hook add SCOPED_PACKAGE_NAME https://hooks.greenkeeper.io/npm/11 84123bd5fcf22427242d3038f73e40d1a51fc18081e90c8a1e6d3c5485690edd
+npm hook add SCOPED_PACKAGE_NAME https://hooks.greenkeeper.io/npm/11 84123bd5fcf22427242d3038f73e40d1a51fc18081e90c8a1e6d3c5485690edd
 
 # Add all private packages in a scope
-wombat hook add SCOPE_NAME https://hooks.greenkeeper.io/npm/11 84123bd5fcf22427242d3038f73e40d1a51fc18081e90c8a1e6d3c5485690edd
+npm hook add SCOPE_NAME https://hooks.greenkeeper.io/npm/11 84123bd5fcf22427242d3038f73e40d1a51fc18081e90c8a1e6d3c5485690edd
 
 # Add all private packages by a specific owner
-wombat hook add --type owner OWNER_NAME https://hooks.greenkeeper.io/npm/11 84123bd5fcf22427242d3038f73e40d1a51fc18081e90c8a1e6d3c5485690edd
+npm hook add --type owner OWNER_NAME https://hooks.greenkeeper.io/npm/11 84123bd5fcf22427242d3038f73e40d1a51fc18081e90c8a1e6d3c5485690edd
 \`\`\`
 
-For additional options and information, please consult the [Wombat docs](https://www.npmjs.com/package/wombat).
+For additional options and information, please consult the [npm CLI docs](
+https://docs.npmjs.com/cli/hook.html).
+
+If you are using npm version 5 or below, you need a separate tool called wombat to do this. Globally install wombat via npm and then use the same commands as above, but with \`wombat\` instead of \`npm\`. More in the [Wombat docs](https://www.npmjs.com/package/wombat).
 </details>
 <details>
 <summary>🙈 How to ignore certain dependencies</summary>
@@ -861,27 +861,27 @@ This step only needs to be run once per Greenkeeper _installation_, meaning once
 - These commands can be run on your local machine
 - You must be authenticated for the npm registry in the terminal session you’re using (see [npm login](https://docs.npmjs.com/creating-a-new-npm-user-account#testing-your-new-account-with-npm-login))
 - This is a one-time operation, once you’ve registered the hook with npm, Greenkeeper will get updates until you tell npm to stop sending them, or you uninstall Greenkeeper on your org or user account.
-- Make sure you replace the placeholders below with the actual values you need:
+- ⚠️ Make sure you replace the placeholders below with the actual values you need:
   - \`SCOPED_PACKAGE_NAME\`: A full scoped package name, such as \`@megacorp/widget\`
   - \`SCOPE_NAME\`: Just the scope name: \`@megacorp\`
   - \`OWNER_NAME\`: An npm username: \`substack\`
 
 \`\`\`bash
-# First, install npm's wombat CLI to be able to create npm hooks
-npm install --global wombat
-
-# Some of the things you can do now:
+# Some of the things you can do with npm hooks:
 # Add a single private scoped package
-wombat hook add SCOPED_PACKAGE_NAME https://hooks.greenkeeper.io/npm/11 84123bd5fcf22427242d3038f73e40d1a51fc18081e90c8a1e6d3c5485690edd
+npm hook add SCOPED_PACKAGE_NAME https://hooks.greenkeeper.io/npm/11 84123bd5fcf22427242d3038f73e40d1a51fc18081e90c8a1e6d3c5485690edd
 
 # Add all private packages in a scope
-wombat hook add SCOPE_NAME https://hooks.greenkeeper.io/npm/11 84123bd5fcf22427242d3038f73e40d1a51fc18081e90c8a1e6d3c5485690edd
+npm hook add SCOPE_NAME https://hooks.greenkeeper.io/npm/11 84123bd5fcf22427242d3038f73e40d1a51fc18081e90c8a1e6d3c5485690edd
 
 # Add all private packages by a specific owner
-wombat hook add --type owner OWNER_NAME https://hooks.greenkeeper.io/npm/11 84123bd5fcf22427242d3038f73e40d1a51fc18081e90c8a1e6d3c5485690edd
+npm hook add --type owner OWNER_NAME https://hooks.greenkeeper.io/npm/11 84123bd5fcf22427242d3038f73e40d1a51fc18081e90c8a1e6d3c5485690edd
 \`\`\`
 
-For additional options and information, please consult the [Wombat docs](https://www.npmjs.com/package/wombat).
+For additional options and information, please consult the [npm CLI docs](
+https://docs.npmjs.com/cli/hook.html).
+
+If you are using npm version 5 or below, you need a separate tool called wombat to do this. Globally install wombat via npm and then use the same commands as above, but with \`wombat\` instead of \`npm\`. More in the [Wombat docs](https://www.npmjs.com/package/wombat).
 </details>
 <details>
 <summary>🙈 How to ignore certain dependencies</summary>
@@ -989,27 +989,27 @@ This step only needs to be run once per Greenkeeper _installation_, meaning once
 - These commands can be run on your local machine
 - You must be authenticated for the npm registry in the terminal session you’re using (see [npm login](https://docs.npmjs.com/creating-a-new-npm-user-account#testing-your-new-account-with-npm-login))
 - This is a one-time operation, once you’ve registered the hook with npm, Greenkeeper will get updates until you tell npm to stop sending them, or you uninstall Greenkeeper on your org or user account.
-- Make sure you replace the placeholders below with the actual values you need:
+- ⚠️ Make sure you replace the placeholders below with the actual values you need:
   - \`SCOPED_PACKAGE_NAME\`: A full scoped package name, such as \`@megacorp/widget\`
   - \`SCOPE_NAME\`: Just the scope name: \`@megacorp\`
   - \`OWNER_NAME\`: An npm username: \`substack\`
 
 \`\`\`bash
-# First, install npm's wombat CLI to be able to create npm hooks
-npm install --global wombat
-
-# Some of the things you can do now:
+# Some of the things you can do with npm hooks:
 # Add a single private scoped package
-wombat hook add SCOPED_PACKAGE_NAME https://hooks.greenkeeper.io/npm/11 84123bd5fcf22427242d3038f73e40d1a51fc18081e90c8a1e6d3c5485690edd
+npm hook add SCOPED_PACKAGE_NAME https://hooks.greenkeeper.io/npm/11 84123bd5fcf22427242d3038f73e40d1a51fc18081e90c8a1e6d3c5485690edd
 
 # Add all private packages in a scope
-wombat hook add SCOPE_NAME https://hooks.greenkeeper.io/npm/11 84123bd5fcf22427242d3038f73e40d1a51fc18081e90c8a1e6d3c5485690edd
+npm hook add SCOPE_NAME https://hooks.greenkeeper.io/npm/11 84123bd5fcf22427242d3038f73e40d1a51fc18081e90c8a1e6d3c5485690edd
 
 # Add all private packages by a specific owner
-wombat hook add --type owner OWNER_NAME https://hooks.greenkeeper.io/npm/11 84123bd5fcf22427242d3038f73e40d1a51fc18081e90c8a1e6d3c5485690edd
+npm hook add --type owner OWNER_NAME https://hooks.greenkeeper.io/npm/11 84123bd5fcf22427242d3038f73e40d1a51fc18081e90c8a1e6d3c5485690edd
 \`\`\`
 
-For additional options and information, please consult the [Wombat docs](https://www.npmjs.com/package/wombat).
+For additional options and information, please consult the [npm CLI docs](
+https://docs.npmjs.com/cli/hook.html).
+
+If you are using npm version 5 or below, you need a separate tool called wombat to do this. Globally install wombat via npm and then use the same commands as above, but with \`wombat\` instead of \`npm\`. More in the [Wombat docs](https://www.npmjs.com/package/wombat).
 </details>
 <details>
 <summary>🙈 How to ignore certain dependencies</summary>
@@ -1117,27 +1117,27 @@ This step only needs to be run once per Greenkeeper _installation_, meaning once
 - These commands can be run on your local machine
 - You must be authenticated for the npm registry in the terminal session you’re using (see [npm login](https://docs.npmjs.com/creating-a-new-npm-user-account#testing-your-new-account-with-npm-login))
 - This is a one-time operation, once you’ve registered the hook with npm, Greenkeeper will get updates until you tell npm to stop sending them, or you uninstall Greenkeeper on your org or user account.
-- Make sure you replace the placeholders below with the actual values you need:
+- ⚠️ Make sure you replace the placeholders below with the actual values you need:
   - \`SCOPED_PACKAGE_NAME\`: A full scoped package name, such as \`@megacorp/widget\`
   - \`SCOPE_NAME\`: Just the scope name: \`@megacorp\`
   - \`OWNER_NAME\`: An npm username: \`substack\`
 
 \`\`\`bash
-# First, install npm's wombat CLI to be able to create npm hooks
-npm install --global wombat
-
-# Some of the things you can do now:
+# Some of the things you can do with npm hooks:
 # Add a single private scoped package
-wombat hook add SCOPED_PACKAGE_NAME https://hooks.greenkeeper.io/npm/11 84123bd5fcf22427242d3038f73e40d1a51fc18081e90c8a1e6d3c5485690edd
+npm hook add SCOPED_PACKAGE_NAME https://hooks.greenkeeper.io/npm/11 84123bd5fcf22427242d3038f73e40d1a51fc18081e90c8a1e6d3c5485690edd
 
 # Add all private packages in a scope
-wombat hook add SCOPE_NAME https://hooks.greenkeeper.io/npm/11 84123bd5fcf22427242d3038f73e40d1a51fc18081e90c8a1e6d3c5485690edd
+npm hook add SCOPE_NAME https://hooks.greenkeeper.io/npm/11 84123bd5fcf22427242d3038f73e40d1a51fc18081e90c8a1e6d3c5485690edd
 
 # Add all private packages by a specific owner
-wombat hook add --type owner OWNER_NAME https://hooks.greenkeeper.io/npm/11 84123bd5fcf22427242d3038f73e40d1a51fc18081e90c8a1e6d3c5485690edd
+npm hook add --type owner OWNER_NAME https://hooks.greenkeeper.io/npm/11 84123bd5fcf22427242d3038f73e40d1a51fc18081e90c8a1e6d3c5485690edd
 \`\`\`
 
-For additional options and information, please consult the [Wombat docs](https://www.npmjs.com/package/wombat).
+For additional options and information, please consult the [npm CLI docs](
+https://docs.npmjs.com/cli/hook.html).
+
+If you are using npm version 5 or below, you need a separate tool called wombat to do this. Globally install wombat via npm and then use the same commands as above, but with \`wombat\` instead of \`npm\`. More in the [Wombat docs](https://www.npmjs.com/package/wombat).
 </details>
 <details>
 <summary>🙈 How to ignore certain dependencies</summary>
@@ -1245,27 +1245,27 @@ This step only needs to be run once per Greenkeeper _installation_, meaning once
 - These commands can be run on your local machine
 - You must be authenticated for the npm registry in the terminal session you’re using (see [npm login](https://docs.npmjs.com/creating-a-new-npm-user-account#testing-your-new-account-with-npm-login))
 - This is a one-time operation, once you’ve registered the hook with npm, Greenkeeper will get updates until you tell npm to stop sending them, or you uninstall Greenkeeper on your org or user account.
-- Make sure you replace the placeholders below with the actual values you need:
+- ⚠️ Make sure you replace the placeholders below with the actual values you need:
   - \`SCOPED_PACKAGE_NAME\`: A full scoped package name, such as \`@megacorp/widget\`
   - \`SCOPE_NAME\`: Just the scope name: \`@megacorp\`
   - \`OWNER_NAME\`: An npm username: \`substack\`
 
 \`\`\`bash
-# First, install npm's wombat CLI to be able to create npm hooks
-npm install --global wombat
-
-# Some of the things you can do now:
+# Some of the things you can do with npm hooks:
 # Add a single private scoped package
-wombat hook add SCOPED_PACKAGE_NAME https://hooks.greenkeeper.io/npm/11 84123bd5fcf22427242d3038f73e40d1a51fc18081e90c8a1e6d3c5485690edd
+npm hook add SCOPED_PACKAGE_NAME https://hooks.greenkeeper.io/npm/11 84123bd5fcf22427242d3038f73e40d1a51fc18081e90c8a1e6d3c5485690edd
 
 # Add all private packages in a scope
-wombat hook add SCOPE_NAME https://hooks.greenkeeper.io/npm/11 84123bd5fcf22427242d3038f73e40d1a51fc18081e90c8a1e6d3c5485690edd
+npm hook add SCOPE_NAME https://hooks.greenkeeper.io/npm/11 84123bd5fcf22427242d3038f73e40d1a51fc18081e90c8a1e6d3c5485690edd
 
 # Add all private packages by a specific owner
-wombat hook add --type owner OWNER_NAME https://hooks.greenkeeper.io/npm/11 84123bd5fcf22427242d3038f73e40d1a51fc18081e90c8a1e6d3c5485690edd
+npm hook add --type owner OWNER_NAME https://hooks.greenkeeper.io/npm/11 84123bd5fcf22427242d3038f73e40d1a51fc18081e90c8a1e6d3c5485690edd
 \`\`\`
 
-For additional options and information, please consult the [Wombat docs](https://www.npmjs.com/package/wombat).
+For additional options and information, please consult the [npm CLI docs](
+https://docs.npmjs.com/cli/hook.html).
+
+If you are using npm version 5 or below, you need a separate tool called wombat to do this. Globally install wombat via npm and then use the same commands as above, but with \`wombat\` instead of \`npm\`. More in the [Wombat docs](https://www.npmjs.com/package/wombat).
 </details>
 <details>
 <summary>🙈 How to ignore certain dependencies</summary>
@@ -1373,27 +1373,27 @@ This step only needs to be run once per Greenkeeper _installation_, meaning once
 - These commands can be run on your local machine
 - You must be authenticated for the npm registry in the terminal session you’re using (see [npm login](https://docs.npmjs.com/creating-a-new-npm-user-account#testing-your-new-account-with-npm-login))
 - This is a one-time operation, once you’ve registered the hook with npm, Greenkeeper will get updates until you tell npm to stop sending them, or you uninstall Greenkeeper on your org or user account.
-- Make sure you replace the placeholders below with the actual values you need:
+- ⚠️ Make sure you replace the placeholders below with the actual values you need:
   - \`SCOPED_PACKAGE_NAME\`: A full scoped package name, such as \`@megacorp/widget\`
   - \`SCOPE_NAME\`: Just the scope name: \`@megacorp\`
   - \`OWNER_NAME\`: An npm username: \`substack\`
 
 \`\`\`bash
-# First, install npm's wombat CLI to be able to create npm hooks
-npm install --global wombat
-
-# Some of the things you can do now:
+# Some of the things you can do with npm hooks:
 # Add a single private scoped package
-wombat hook add SCOPED_PACKAGE_NAME https://hooks.greenkeeper.io/npm/11 84123bd5fcf22427242d3038f73e40d1a51fc18081e90c8a1e6d3c5485690edd
+npm hook add SCOPED_PACKAGE_NAME https://hooks.greenkeeper.io/npm/11 84123bd5fcf22427242d3038f73e40d1a51fc18081e90c8a1e6d3c5485690edd
 
 # Add all private packages in a scope
-wombat hook add SCOPE_NAME https://hooks.greenkeeper.io/npm/11 84123bd5fcf22427242d3038f73e40d1a51fc18081e90c8a1e6d3c5485690edd
+npm hook add SCOPE_NAME https://hooks.greenkeeper.io/npm/11 84123bd5fcf22427242d3038f73e40d1a51fc18081e90c8a1e6d3c5485690edd
 
 # Add all private packages by a specific owner
-wombat hook add --type owner OWNER_NAME https://hooks.greenkeeper.io/npm/11 84123bd5fcf22427242d3038f73e40d1a51fc18081e90c8a1e6d3c5485690edd
+npm hook add --type owner OWNER_NAME https://hooks.greenkeeper.io/npm/11 84123bd5fcf22427242d3038f73e40d1a51fc18081e90c8a1e6d3c5485690edd
 \`\`\`
 
-For additional options and information, please consult the [Wombat docs](https://www.npmjs.com/package/wombat).
+For additional options and information, please consult the [npm CLI docs](
+https://docs.npmjs.com/cli/hook.html).
+
+If you are using npm version 5 or below, you need a separate tool called wombat to do this. Globally install wombat via npm and then use the same commands as above, but with \`wombat\` instead of \`npm\`. More in the [Wombat docs](https://www.npmjs.com/package/wombat).
 </details>
 <details>
 <summary>🙈 How to ignore certain dependencies</summary>

--- a/test/jobs/create-initial-branch.js
+++ b/test/jobs/create-initial-branch.js
@@ -39,8 +39,8 @@ describe('create initial branch', () => {
     await Promise.all([
       removeIfExists(installations, '123'),
       removeIfExists(payments, '123'),
-      removeIfExists(repositories, '42', '43', '44', '45', '46', '47', '48', '49', '50', '51', 'too-many-packages',
-        '42:branch:1234abcd', '47:branch:1234abcd', '48:branch:1234abcd', '49:branch:1234abcd', '50:branch:1234abcd', '51:branch:1234abcd', 'lockfile-42', 'lockfile-42:branch:1234abcd')
+      removeIfExists(repositories, '42', '43', '44', '45', '46', '47', '48', '49', '50', '51', '52', 'too-many-packages',
+        '42:branch:1234abcd', '47:branch:1234abcd', '48:branch:1234abcd', '49:branch:1234abcd', '50:branch:1234abcd', '51:branch:1234abcd', '52:branch:1234abcd', 'lockfile-42', 'lockfile-42:branch:1234abcd')
     ])
     nock.cleanAll()
   })


### PR DESCRIPTION
Fixes a problem where some statuses would go unused, leading to missing initial PRs.

Also updates the initial PR text to include adding hooks with npm (not just wombat), and adds an extra text for initial PRs in which no deps were updated, because everything was already up-to-date.