### PR TITLE
fix(on-status): use combined status

### DIFF
--- a/lib/on-branch-status.js
+++ b/lib/on-branch-status.js
@@ -73,37 +73,31 @@ module.exports = async function (repository, sha, installation) {
   }
 
   /* 1. Get all statuses for this branch
-  https://developer.github.com/v3/repos/statuses/#list-statuses-for-a-specific-ref
-  (getStatuses) in our version of Octokit
+  https://developer.github.com/v3/repos/statuses/#get-the-combined-status-for-a-specific-ref
 
-  This `combined` object echoes the combined state from https://developer.github.com/v3/repos/statuses/#get-the-combined-status-for-a-specific-ref, but we use it to generate a state that takes both statuses AND checks into account, whereas the original only handles statuses.
-
+    Note that there may be no statuses, only checks, in this case, GitHub returns:
+    "state": "pending",
+    "statuses": []
   */
-  let combined = {
-    statuses: [],
-    state: undefined
-  }
-  combined.statuses = await GithubQueue(installationId).read(github => github.repos.getStatuses({
+
+  let combined = await GithubQueue(installationId).read(github => github.repos.getCombinedStatusForRef({
     owner,
     repo,
     ref: sha
   }))
 
-  if (combined.statuses.length > 0) {
-    const hasPendingStatuses = combined.statuses.find(status => status.state === 'pending')
-    if (hasPendingStatuses) {
-      log.warn('Has pending statuses, bailing.', { combined })
+  if (combined.state === 'pending' && combined.statuses.length === 0) {
+    combined.state = 'success'
+    log.info('No statuses, continuing with checks.')
+    // this is fine, this means that there are no statuses on the repo at all, but there
+    // should be checks (otherwise we wouldn’t be in this file)
+  } else {
+    // We _do_ continue on failure since the `handleBranchStatus` job can also
+    // comment with notifications about failing builds.
+    if (!_.includes(['success', 'failure'], combined.state)) {
+      log.info('exited: build state is neither success nor failure ', { state: combined.state })
       return
     }
-    const hasFailingStatuses = combined.statuses.find(status => status.state === 'failure' || status.state === 'error')
-    if (hasFailingStatuses) {
-      combined.state = 'failure'
-    } else {
-      combined.state = 'success'
-    }
-    log.info(`After all statuses completed, combined state set to ${combined.state}`, { combined })
-  } else {
-    log.info('No statuses, continuing with checks.')
   }
 
   /* 2. Get the combined Checks for this branch

--- a/test/jobs/github-event/check_suite/completed.js
+++ b/test/jobs/github-event/check_suite/completed.js
@@ -46,8 +46,11 @@ describe('github-event checksuite_completed', async () => {
       .get('/rate_limit')
       .optionally()
       .reply(200, {})
-      .get('/repos/club/mate/commits/deadbeef/statuses')
-      .reply(200, [])
+      .get('/repos/club/mate/commits/deadbeef/status')
+      .reply(200, {
+        state: 'pending',
+        statuses: []
+      })
       .get('/repos/club/mate/commits/deadbeef/check-runs')
       .reply(200, {
         'total_count': 2,
@@ -122,8 +125,11 @@ describe('github-event checksuite_completed', async () => {
       .get('/rate_limit')
       .optionally()
       .reply(200, {})
-      .get('/repos/club/mate/commits/catbus/statuses')
-      .reply(200, [])
+      .get('/repos/club/mate/commits/catbus/status')
+      .reply(200, {
+        state: 'pending',
+        statuses: []
+      })
       .get('/repos/club/mate/commits/catbus/check-runs')
       .reply(200, {
         'total_count': 2,
@@ -191,41 +197,11 @@ describe('github-event checksuite_completed', async () => {
       .get('/rate_limit')
       .optionally()
       .reply(200, {})
-      .get('/repos/club/mate/commits/busdog/statuses')
-      .reply(200, [
-        {
-          'url': 'https://api.github.com/repos/octocat/Hello-World/statuses/6dcb09b5b57875f334f61aebed695e2e4193db5e',
-          'avatar_url': 'https://github.com/images/error/hubot_happy.gif',
-          'id': 1,
-          'node_id': 'MDY6U3RhdHVzMQ==',
-          'state': 'success',
-          'description': 'Build has completed successfully',
-          'target_url': 'https://ci.example.com/1000/output',
-          'context': 'continuous-integration/jenkins',
-          'created_at': '2012-07-20T01:19:13Z',
-          'updated_at': '2012-07-20T01:19:13Z',
-          'creator': {
-            'login': 'octocat',
-            'id': 1,
-            'node_id': 'MDQ6VXNlcjE=',
-            'avatar_url': 'https://github.com/images/error/octocat_happy.gif',
-            'gravatar_id': '',
-            'url': 'https://api.github.com/users/octocat',
-            'html_url': 'https://github.com/octocat',
-            'followers_url': 'https://api.github.com/users/octocat/followers',
-            'following_url': 'https://api.github.com/users/octocat/following{/other_user}',
-            'gists_url': 'https://api.github.com/users/octocat/gists{/gist_id}',
-            'starred_url': 'https://api.github.com/users/octocat/starred{/owner}{/repo}',
-            'subscriptions_url': 'https://api.github.com/users/octocat/subscriptions',
-            'organizations_url': 'https://api.github.com/users/octocat/orgs',
-            'repos_url': 'https://api.github.com/users/octocat/repos',
-            'events_url': 'https://api.github.com/users/octocat/events{/privacy}',
-            'received_events_url': 'https://api.github.com/users/octocat/received_events',
-            'type': 'User',
-            'site_admin': false
-          }
-        }
-      ])
+      .get('/repos/club/mate/commits/busdog/status')
+      .reply(200, {
+        state: 'success',
+        statuses: []
+      })
       .get('/repos/club/mate/commits/busdog/check-runs')
       .reply(200, {
         'total_count': 2,
@@ -290,8 +266,11 @@ describe('github-event checksuite_completed', async () => {
       .get('/rate_limit')
       .optionally()
       .reply(200, {})
-      .get('/repos/club/mate/commits/pelicanballoon/statuses')
-      .reply(200, [])
+      .get('/repos/club/mate/commits/pelicanballoon/status')
+      .reply(200, {
+        state: 'pending',
+        statuses: []
+      })
       .get('/repos/club/mate/commits/pelicanballoon/check-runs')
       .reply(200, {
         'total_count': 2,
@@ -344,7 +323,7 @@ describe('github-event checksuite_completed', async () => {
 
   test('no initial pr, one successful status, two successful checks', async () => {
     const { repositories } = await dbs()
-    expect.assertions(4)
+    expect.assertions(3)
     const githubStatus = require('../../../../jobs/github-event/status')
 
     nock('https://api.github.com')
@@ -356,41 +335,11 @@ describe('github-event checksuite_completed', async () => {
       .get('/rate_limit')
       .optionally()
       .reply(200, {})
-      .get('/repos/club/mate/commits/giraffeplane/statuses')
-      .reply(200, [
-        {
-          'url': 'https://api.github.com/repos/octocat/Hello-World/statuses/6dcb09b5b57875f334f61aebed695e2e4193db5e',
-          'avatar_url': 'https://github.com/images/error/hubot_happy.gif',
-          'id': 1,
-          'node_id': 'MDY6U3RhdHVzMQ==',
-          'state': 'success',
-          'description': 'Build has completed successfully',
-          'target_url': 'https://ci.example.com/1000/output',
-          'context': 'continuous-integration/jenkins',
-          'created_at': '2012-07-20T01:19:13Z',
-          'updated_at': '2012-07-20T01:19:13Z',
-          'creator': {
-            'login': 'octocat',
-            'id': 1,
-            'node_id': 'MDQ6VXNlcjE=',
-            'avatar_url': 'https://github.com/images/error/octocat_happy.gif',
-            'gravatar_id': '',
-            'url': 'https://api.github.com/users/octocat',
-            'html_url': 'https://github.com/octocat',
-            'followers_url': 'https://api.github.com/users/octocat/followers',
-            'following_url': 'https://api.github.com/users/octocat/following{/other_user}',
-            'gists_url': 'https://api.github.com/users/octocat/gists{/gist_id}',
-            'starred_url': 'https://api.github.com/users/octocat/starred{/owner}{/repo}',
-            'subscriptions_url': 'https://api.github.com/users/octocat/subscriptions',
-            'organizations_url': 'https://api.github.com/users/octocat/orgs',
-            'repos_url': 'https://api.github.com/users/octocat/repos',
-            'events_url': 'https://api.github.com/users/octocat/events{/privacy}',
-            'received_events_url': 'https://api.github.com/users/octocat/received_events',
-            'type': 'User',
-            'site_admin': false
-          }
-        }
-      ])
+      .get('/repos/club/mate/commits/giraffeplane/status')
+      .reply(200, {
+        state: 'success',
+        statuses: []
+      })
       .get('/repos/club/mate/commits/giraffeplane/check-runs')
       .reply(200, {
         'total_count': 2,
@@ -441,8 +390,6 @@ describe('github-event checksuite_completed', async () => {
 
     expect(newJob).toBeTruthy()
     expect(newJob.data.combined.state).toEqual('success')
-    // Checks are also added to the combined.statuses array, so 2 checks + 1 status = 3
-    expect(newJob.data.combined.statuses).toHaveLength(3)
     expect(newJob.data.name).toEqual('create-initial-pr')
   })
 })

--- a/test/jobs/github-event/status.js
+++ b/test/jobs/github-event/status.js
@@ -42,12 +42,11 @@ describe('github-event status', async () => {
       .get('/rate_limit')
       .optionally()
       .reply(200, {})
-      .get('/repos/club/mate/commits/deadbeef/statuses')
-      .reply(200, [{
-        'state': 'success',
-        'description': 'Build has completed successfully',
-        'context': 'continuous-integration/jenkins'
-      }])
+      .get('/repos/club/mate/commits/deadbeef/status')
+      .reply(200, {
+        state: 'success',
+        statuses: []
+      })
       .get('/repos/club/mate/commits/deadbeef/check-runs')
       .reply(200, {
         'total_count': 0,
@@ -85,7 +84,7 @@ describe('github-event status', async () => {
 
   test('initial pr with 2 checks, 1 status', async () => {
     const { repositories } = await dbs()
-    expect.assertions(7)
+    expect.assertions(6)
     const githubStatus = require('../../../jobs/github-event/status')
 
     nock('https://api.github.com')
@@ -97,12 +96,11 @@ describe('github-event status', async () => {
       .get('/rate_limit')
       .optionally()
       .reply(200, {})
-      .get('/repos/club/mate/commits/muppets/statuses')
-      .reply(200, [{
-        'state': 'success',
-        'description': 'Build has completed successfully',
-        'context': 'continuous-integration/jenkins'
-      }])
+      .get('/repos/club/mate/commits/muppets/status')
+      .reply(200, {
+        state: 'success',
+        statuses: []
+      })
       .get('/repos/club/mate/commits/muppets/check-runs')
       .reply(200, {
         'total_count': 2,
@@ -158,12 +156,11 @@ describe('github-event status', async () => {
     expect(job.combined.state).toEqual('success')
     expect(job.repository.id).toBe(42)
     expect(job.installationId).toEqual(1336)
-    expect(job.combined.statuses).toHaveLength(3)
   })
 
   test('initial pr fails with a failed check, two successful statuses', async () => {
     const { repositories } = await dbs()
-    expect.assertions(7)
+    expect.assertions(6)
     const githubStatus = require('../../../jobs/github-event/status')
 
     nock('https://api.github.com')
@@ -175,16 +172,11 @@ describe('github-event status', async () => {
       .get('/rate_limit')
       .optionally()
       .reply(200, {})
-      .get('/repos/club/mate/commits/hats/statuses')
-      .reply(200, [{
-        'state': 'success',
-        'description': 'Build has completed successfully',
-        'context': 'continuous-integration/jenkins'
-      }, {
-        'state': 'success',
-        'description': 'PR is verified',
-        'context': 'greenkeeper/verify'
-      }])
+      .get('/repos/club/mate/commits/hats/status')
+      .reply(200, {
+        state: 'success',
+        statuses: []
+      })
       .get('/repos/club/mate/commits/hats/check-runs')
       .reply(200, {
         'total_count': 2,
@@ -240,7 +232,6 @@ describe('github-event status', async () => {
     expect(job.combined.state).toEqual('failure')
     expect(job.repository.id).toBe(42)
     expect(job.installationId).toEqual(1336)
-    expect(job.combined.statuses).toHaveLength(4)
   })
 
   test('initial pr by user, 1 status, no checks', async () => {
@@ -258,12 +249,11 @@ describe('github-event status', async () => {
       .get('/rate_limit')
       .optionally()
       .reply(200, {})
-      .get('/repos/club/mate/commits/deadbeef/statuses')
-      .reply(200, [{
-        'state': 'success',
-        'description': 'Build has completed successfully',
-        'context': 'continuous-integration/jenkins'
-      }])
+      .get('/repos/club/mate/commits/deadbeef/status')
+      .reply(200, {
+        state: 'success',
+        statuses: []
+      })
       .get('/repos/club/mate/commits/deadbeef/check-runs')
       .reply(200, {
         'total_count': 0,
@@ -323,12 +313,11 @@ describe('github-event status', async () => {
       .get('/rate_limit')
       .optionally()
       .reply(200, {})
-      .get('/repos/lara/monorepo/commits/abcdf1234/statuses')
-      .reply(200, [{
-        'state': 'success',
-        'description': 'Build has completed successfully',
-        'context': 'continuous-integration/jenkins'
-      }])
+      .get('/repos/lara/monorepo/commits/abcdf1234/status')
+      .reply(200, {
+        state: 'success',
+        statuses: []
+      })
       .get('/repos/lara/monorepo/commits/abcdf1234/check-runs')
       .reply(200, {
         'total_count': 0,
@@ -385,12 +374,11 @@ describe('github-event status', async () => {
       .get('/rate_limit')
       .optionally()
       .reply(200, {})
-      .get('/repos/plant/monorepo/commits/plantsarethebest11/statuses')
-      .reply(200, [{
-        'state': 'success',
-        'description': 'Build has completed successfully',
-        'context': 'continuous-integration/jenkins'
-      }])
+      .get('/repos/plant/monorepo/commits/plantsarethebest11/status')
+      .reply(200, {
+        state: 'success',
+        statuses: []
+      })
       .get('/repos/plant/monorepo/commits/plantsarethebest11/check-runs')
       .reply(200, {
         'total_count': 0,
@@ -464,12 +452,11 @@ describe('github-event status', async () => {
       .get('/rate_limit')
       .optionally()
       .reply(200, {})
-      .get('/repos/club/mate/commits/deadbeef2/statuses')
-      .reply(200, [{
-        'state': 'success',
-        'description': 'Build has completed successfully',
-        'context': 'continuous-integration/jenkins'
-      }])
+      .get('/repos/club/mate/commits/deadbeef2/status')
+      .reply(200, {
+        state: 'success',
+        statuses: []
+      })
       .get('/repos/club/mate/commits/deadbeef2/check-runs')
       .reply(200, {
         'total_count': 0,
@@ -523,12 +510,11 @@ describe('github-event status', async () => {
       .get('/rate_limit')
       .optionally()
       .reply(200, {})
-      .get('/repos/club/mate/commits/gnu2/statuses')
-      .reply(200, [{
-        'state': 'success',
-        'description': 'Build has completed successfully',
-        'context': 'continuous-integration/jenkins'
-      }])
+      .get('/repos/club/mate/commits/gnu2/status')
+      .reply(200, {
+        state: 'success',
+        statuses: []
+      })
       .get('/repos/club/mate/commits/gnu2/check-runs')
       .reply(403, {
         'message': 'Resource not accessible by integration',


### PR DESCRIPTION
Get combined statuses for ref instead of just statuses, since the latter ignores the statuses context and delivers multiple statuses per… thing. Test run, for example.