### PR TITLE
fix: work around octokit inconsistencies

### DIFF
--- a/jobs/github-event/installation/created.js
+++ b/jobs/github-event/installation/created.js
@@ -63,19 +63,20 @@ module.exports = async function ({ installation }) {
     return
   }
 
-  log.info(`github: fetched ${repositories.length} installation repositories`, { repositories })
+  log.info(`github: fetched ${repositories.length} installation repositories`)
   statsd.increment('repositories', repositories.length)
 
   let repoDocs = []
   try {
-    repoDocs = await createDocs({
+    repoDocs = createDocs({
       repositories,
       accountId: doc._id
     })
     // saving installation repos to db
+    log.info(`Preparing to write ${repoDocs.length} repoDocs to the DB`)
     await reposDb.bulkDocs(repoDocs)
   } catch (error) {
-    log.error('error: could not write repoDoc', { error })
+    log.error('error: could not write repoDocs', { error })
   }
   statsd.increment('installs')
   statsd.event('install')


### PR DESCRIPTION
Fetching repositories from installations no longer worked after updating Octokit, partially because the [endpoint](https://octokit.github.io/rest.js/#api-Apps-listRepos) apparently didn’t include the accept header (at least we got `415`s back from GH), and partially because the pagination didn’t flatten the results per page down to one array as suggested in the docs. This fixes both. 