### PR TITLE
fix(lockfiles): handle too large lockfiles

### DIFF
--- a/lib/get-files.js
+++ b/lib/get-files.js
@@ -12,13 +12,13 @@ async function getGithubFile (ghqueue, { path, owner, repo, sha }, log) {
   try {
     return await ghqueue.read(github => github.repos.getContents({ path, owner, repo }))
   } catch (error) {
-    // Sometimes, the requested blob (package-lock.json) is too large to fetch via the gitHub API,
+    // Sometimes, the requested blob (eg. package-lock.json) is too large to fetch via the gitHub API,
     // but we can use the Git Data API to request blobs up to 100 MB in size.
     if (error.status === 'too_large') {
-      log.info('Could not receive contents from GitHub. File is too large', { error: error.message })
+      log.info('Could not receive contents from GitHub. File is too, trying the data api for larger files now', { error: error.message })
       try {
         const allFiles = await ghqueue.read(github => github.gitdata.getTree({ owner, repo, tree_sha: sha }))
-        const file = allFiles.tree.find(file => file.path === 'package-lock.json')
+        const file = allFiles.tree.find(file => file.path === path)
         const blob = await ghqueue.read(github => github.gitdata.getBlob({ owner, repo, file_sha: file.sha }))
         return { name: path, path, content: blob.content }
       } catch (error) {

--- a/lib/get-files.js
+++ b/lib/get-files.js
@@ -11,22 +11,23 @@ const fileList = [
 ]
 
 async function getGithubFile (ghqueue, { path, owner, repo, sha }, log) {
+  let name = path
+  if (path.includes('/')) name = path.split('/')[1]
+
   try {
-    statsd.increment('get_github_file_small', { tag: path })
+    statsd.increment('get_github_file_small', { tag: name })
     return await ghqueue.read(github => github.repos.getContents({ path, owner, repo }))
   } catch (error) {
     // Sometimes, the requested blob (eg. package-lock.json) is too large to fetch via the gitHub API,
     // but we can use the Git Data API to request blobs up to 100 MB in size.
     if (error.status === 'too_large') {
       log.info('Could not receive contents from GitHub. File is too, trying the data api for larger files now', { error: error.message })
-      statsd.increment('get_github_file_large', { tag: path })
+      statsd.increment('get_github_file_large', { tag: name })
       try {
         const allFiles = await ghqueue.read(github => github.gitdata.getTree({ owner, repo, tree_sha: sha, recursive: 1 }))
         const file = allFiles.tree.find(file => file.path === path)
         const blob = await ghqueue.read(github => github.gitdata.getBlob({ owner, repo, file_sha: file.sha }))
 
-        let name = path
-        if (path.includes('/')) name = path.split('/')[1]
         return { name, path, content: blob.content }
       } catch (error) {
         log.info('Could not receive recursive tree from GitHub.', { error: error.message })

--- a/lib/get-files.js
+++ b/lib/get-files.js
@@ -17,12 +17,15 @@ async function getGithubFile (ghqueue, { path, owner, repo, sha }, log) {
     if (error.status === 'too_large') {
       log.info('Could not receive contents from GitHub. File is too, trying the data api for larger files now', { error: error.message })
       try {
-        const allFiles = await ghqueue.read(github => github.gitdata.getTree({ owner, repo, tree_sha: sha }))
+        const allFiles = await ghqueue.read(github => github.gitdata.getTree({ owner, repo, tree_sha: sha, recursive: 1 }))
         const file = allFiles.tree.find(file => file.path === path)
         const blob = await ghqueue.read(github => github.gitdata.getBlob({ owner, repo, file_sha: file.sha }))
-        return { name: path, path, content: blob.content }
+
+        let name = path
+        if (path.includes('/')) name = path.split('/')[1]
+        return { name, path, content: blob.content }
       } catch (error) {
-        log.info('Could not receive trees from GitHub.', { error: error.message })
+        log.info('Could not receive recursive tree from GitHub.', { error: error.message })
         return { name: path, path, content: false }
       }
     } else {

--- a/lib/get-files.js
+++ b/lib/get-files.js
@@ -1,4 +1,6 @@
 const _ = require('lodash')
+const statsd = require('../lib/statsd')
+
 const githubQueue = require('./github-queue')
 
 const fileList = [
@@ -10,12 +12,14 @@ const fileList = [
 
 async function getGithubFile (ghqueue, { path, owner, repo, sha }, log) {
   try {
+    statsd.increment('get_github_file_small', { tag: path })
     return await ghqueue.read(github => github.repos.getContents({ path, owner, repo }))
   } catch (error) {
     // Sometimes, the requested blob (eg. package-lock.json) is too large to fetch via the gitHub API,
     // but we can use the Git Data API to request blobs up to 100 MB in size.
     if (error.status === 'too_large') {
       log.info('Could not receive contents from GitHub. File is too, trying the data api for larger files now', { error: error.message })
+      statsd.increment('get_github_file_large', { tag: path })
       try {
         const allFiles = await ghqueue.read(github => github.gitdata.getTree({ owner, repo, tree_sha: sha, recursive: 1 }))
         const file = allFiles.tree.find(file => file.path === path)

--- a/lib/get-files.js
+++ b/lib/get-files.js
@@ -8,11 +8,26 @@ const fileList = [
   'yarn.lock'
 ]
 
-async function getGithubFile (ghqueue, { path, owner, repo }) {
+async function getGithubFile (ghqueue, { path, owner, repo, sha }, log) {
   try {
     return await ghqueue.read(github => github.repos.getContents({ path, owner, repo }))
-  } catch (e) {
-    return { name: path, path, content: false }
+  } catch (error) {
+    // Sometimes, the requested blob (package-lock.json) is too large to fetch via the gitHub API,
+    // but we can use the Git Data API to request blobs up to 100 MB in size.
+    if (error.status === 'too_large') {
+      log.info('Could not receive contents from GitHub. File is too large', { error: error.message })
+      try {
+        const allFiles = await ghqueue.read(github => github.gitdata.getTree({ owner, repo, tree_sha: sha }))
+        const file = allFiles.tree.find(file => file.path === 'package-lock.json')
+        const blob = await ghqueue.read(github => github.gitdata.getBlob({ owner, repo, file_sha: file.sha }))
+        return { name: path, path, content: blob.content }
+      } catch (error) {
+        log.info('Could not receive trees from GitHub.', { error: error.message })
+        return { name: path, path, content: false }
+      }
+    } else {
+      return { name: path, path, content: false }
+    }
   }
 }
 
@@ -71,13 +86,13 @@ function addRelatedLockfilePaths (files) {
   return relatedLockfilePaths
 }
 
-async function getFiles (installationId, fullName, files = fileList) {
+async function getFiles ({ installationId, fullName, files = fileList, sha, log }) {
   // Take the package.json paths and look for the lockfiles too!
   const filesAndLockfiles = files.concat(addRelatedLockfilePaths(files))
   const ghqueue = githubQueue(installationId)
   const [owner, repo] = fullName.split('/')
   const filesRequested = await Promise.all(
-    filesAndLockfiles.map((path) => getGithubFile(ghqueue, { path, owner, repo }))
+    filesAndLockfiles.map((path) => getGithubFile(ghqueue, { path, owner, repo, sha }, log))
   )
 
   // returns an object of all files that were

--- a/lib/repository-docs.js
+++ b/lib/repository-docs.js
@@ -59,8 +59,8 @@ async function updateRepoDoc ({ installationId, doc, filePaths, log }) {
     }
     log.info('UpdateRepoDoc: requesting files from GitHub', { files: filePathsFromConfig })
     const filesFromConfig = _.isEmpty(filePathsFromConfig)
-      ? await getFiles(installationId, fullName)
-      : await getFiles(installationId, fullName, filePathsFromConfig)
+      ? await getFiles({ installationId, fullName, sha: doc.headSha, log })
+      : await getFiles({ installationId, fullName, files: filePathsFromConfig, sha: doc.headSha, log })
 
     const files = _.merge(filesFromConfig, defaultFiles)
     // handles multiple paths for files like this:


### PR DESCRIPTION
Requesting a too large package-lock.json causes this:

```
{
  "message": "This API returns blobs up to 1 MB in size. The requested blob is too large to fetch via the API, but you can use the Git Data API to request blobs up to 100 MB in size.",
  "errors": [
    {
      "resource": "Blob",
      "field": "data",
      "code": "too_large"
    }
  ],
  "documentation_url": "https://developer.github.com/v3/repos/contents/#get-contents"
}
```

The gitHub API supports files up to 1 megabyte in size, so we need to use the Git Trees API for larger ones (and blob for the contents)