### PR TITLE
fix(initial-pr): replace deprecated octokit getAllPrs-method

### DIFF
--- a/jobs/create-group-version-branch.js
+++ b/jobs/create-group-version-branch.js
@@ -427,7 +427,7 @@ async function createPr ({ ghqueue, title, body, base, head, owner, repo, log })
     log.warn('Could not create PR', { err })
     if (err.status !== 422) throw err
 
-    const allPrs = await ghqueue.read(github => github.pullRequests.getAll({
+    const allPrs = await ghqueue.read(github => github.pulls.list({
       base,
       head: owner + ':' + head,
       owner,

--- a/jobs/create-initial-pr.js
+++ b/jobs/create-initial-pr.js
@@ -155,7 +155,7 @@ module.exports = async function (
 
     // in case the pull request was already created
     // we just store that PRs info
-    const pr = (await ghqueue.read(github => github.pullRequests.getAll({
+    const pr = (await ghqueue.read(github => github.pulls.list({
       owner,
       repo,
       base,

--- a/jobs/create-initial-subgroup-pr.js
+++ b/jobs/create-initial-subgroup-pr.js
@@ -118,7 +118,7 @@ module.exports = async function (
 
     // in case the pull request was already created
     // we just store that PRs info
-    const pr = (await ghqueue.read(github => github.pullRequests.getAll({
+    const pr = (await ghqueue.read(github => github.pulls.list({
       owner,
       repo,
       base,

--- a/jobs/create-version-branch.js
+++ b/jobs/create-version-branch.js
@@ -422,7 +422,7 @@ async function createPr ({ ghqueue, title, body, base, head, owner, repo, log })
     log.warn('Could not create PR', { err: err.message })
     if (err.status !== 422) throw err
 
-    const allPrs = await ghqueue.read(github => github.pullRequests.getAll({
+    const allPrs = await ghqueue.read(github => github.pulls.list({
       base,
       head: owner + ':' + head,
       owner,


### PR DESCRIPTION
 `github.pullRequests.getAll` is deprecated and `octokit.pulls.list()` works exactly the same way that `octokit.pullRequests.getAll()` worked before