### PR TITLE
Fix: only comment on PR if there are new updates

### DIFF
--- a/test/jobs/__snapshots__/create-group-version-branch.js.snap
+++ b/test/jobs/__snapshots__/create-group-version-branch.js.snap
@@ -179,10 +179,22 @@ Your [Greenkeeper](https://greenkeeper.io) bot :palm_tree:
 }
 `;
 
-exports[`create-group-version-branch new pull request, 1 group, 2 packages, same dependencyType, old PR exists 1`] = `
+exports[`create-group-version-branch no new branch because old pull request has same updates already 1`] = `
+Array [
+  "react/cli-2.0.1",
+]
+`;
+
+exports[`create-group-version-branch no new pull request, but new comment on PR, 1 group, 2 packages, same dependencyType, old PR exists 1`] = `
 "- The \`dependency\` [react](https://www.npmjs.com/package/react) was updated from \`1.0.0\` to \`2.0.0\`.
 
 [Update to these versions instead 🚀](https://github.com/hans/monorepo/compare/master...hans:greenkeeper%2Fdefault%2Fmonorepo.react-20190330170013)"
+`;
+
+exports[`create-group-version-branch no new pull request, but new comment on PR, 1 group, 2 packages, same dependencyType, old PR exists 2`] = `
+Array [
+  "react-2.0.0",
+]
 `;
 
 exports[`create-group-version-branch with lockfiles new pull request, 2 groups, 1 package, same dependencyType, both have lockfiles 1`] = `"{\\"devDependencies\\":{\\"@finnpauls/dep\\":\\"2.0.0\\"}}"`;

--- a/test/jobs/__snapshots__/create-version-branch.js.snap
+++ b/test/jobs/__snapshots__/create-version-branch.js.snap
@@ -6,6 +6,12 @@ exports[`create version branch comment pr 1`] = `
 [Update to this version instead 🚀](https://github.com/finnp/test2/compare/master...finnp:greenkeeper%2F%40finnpauls%2Fdep2-2.0.0)"
 `;
 
+exports[`create version branch comment pr 2`] = `
+Array [
+  "@finnpauls/dep2-2.0.0",
+]
+`;
+
 exports[`create version branch for dependencies from monorepos new pull request 1`] = `
 "
 ## There have been updates to the *colors* monorepo: 
@@ -263,4 +269,19 @@ If you don’t accept this pull request, your project will work just like it did
 Your [Greenkeeper](https://greenkeeper.io) bot :palm_tree:
 
 "
+`;
+
+exports[`create version branch no new branch, because comment already exists 1`] = `
+Object {
+  "_id": "43:pr:6",
+  "_rev": "1-a82652e0cb814a2cdf20f636634b45df",
+  "comments": Array [
+    "@finnpauls/dep3-2.0.0",
+  ],
+  "dependency": "@finnpauls/dep3",
+  "number": 6,
+  "repositoryId": "43",
+  "state": "open",
+  "type": "pr",
+}
 `;

--- a/test/jobs/create-group-version-branch.js
+++ b/test/jobs/create-group-version-branch.js
@@ -785,6 +785,7 @@ describe('create-group-version-branch', async () => {
       accountId: '123-two-packages',
       repositoryId: '123-monorepo',
       version: '2.0.0',
+      comments: [],
       oldVersion: '^1.0.0',
       dependency: 'react',
       initial: false,


### PR DESCRIPTION
- changes the comments in the pr database doc from `2.0.9` to `@gatsby/cli-2.0.9`
- we can check if there is anything new in the branch or if we have one like this before

TODO: 
- [x] tests