### PR TITLE
docs: switch travis-ci.org to travis-ci.com

### DIFF
--- a/content/timeout-issue.js
+++ b/content/timeout-issue.js
@@ -6,7 +6,7 @@ module.exports = ({ fullName }) =>
 
 To enable Greenkeeper, you need to make sure that a [commit status](https://help.github.com/articles/about-statuses/) is reported on all branches. This is required by Greenkeeper because it uses your CI build statuses to figure out when to notify you about breaking changes.
 
-Since we didn’t receive a CI status on the ${branchLink(fullName)} branch, it’s possible that you don’t have CI set up yet. We recommend using [Travis CI](https://travis-ci.org), but Greenkeeper will work with every other CI service as well.
+Since we didn’t receive a CI status on the ${branchLink(fullName)} branch, it’s possible that you don’t have CI set up yet. We recommend using [Travis CI](https://travis-ci.com), but Greenkeeper will work with every other CI service as well.
 
 If you _have_ already set up a CI for this repository, you might need to check how it’s configured. Make sure it is set to run on all new branches. If you don’t want it to run on absolutely every branch, you can whitelist branches starting with ${md.code('greenkeeper/')}.
 


### PR DESCRIPTION
Travis CI has moved from travis-ci.org to travis-ci.com for public and
private repos and advocates new users only using travis-ci.com

Official reference: https://blog.travis-ci.com/2018-05-02-open-source-projects-on-travis-ci-com-with-github-apps