### PR TITLE
Fix/monorepo fetch info

### DIFF
--- a/start-couchdb
+++ b/start-couchdb
@@ -30,4 +30,4 @@ until $(curl --output /dev/null --silent --head --fail http://localhost:5984); d
 done
 
 # speed up couchdb operations
-curl -X PUT http://localhost:5984/_node/_local/_config/couchdb/delayed_commits -d '"true"'
+curl -sX PUT http://localhost:5984/_node/_local/_config/couchdb/delayed_commits -d '"true"' > /dev/null 2>&1

--- a/test/utils/__snapshots__/initial-branch-utils.js.snap
+++ b/test/utils/__snapshots__/initial-branch-utils.js.snap
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`initial branch utils getDependenciesFromPackageFiles duplicate dependency across dep type 1`] = `
+Array [
+  Object {
+    "name": "@finnpauls/dep",
+    "type": "devDependencies",
+    "version": "1.0.0",
+  },
+]
+`;
+
+exports[`initial branch utils getDependenciesFromPackageFiles single devDependency 1`] = `
+Array [
+  Object {
+    "name": "@finnpauls/dep",
+    "type": "devDependencies",
+    "version": "1.0.0",
+  },
+]
+`;
+
+exports[`initial branch utils getDependenciesFromPackageFiles workspace 1`] = `
+Array [
+  Object {
+    "name": "@finnpauls/blup",
+    "type": "devDependencies",
+    "version": "1.0.0",
+  },
+  Object {
+    "name": "florp",
+    "type": "dependencies",
+    "version": "1.2.3",
+  },
+]
+`;

--- a/test/utils/initial-branch-utils.js
+++ b/test/utils/initial-branch-utils.js
@@ -87,3 +87,45 @@ describe('create initial branch', () => {
     expect(updatedDependencies[0].newVersion).toEqual('2.0.0')
   })
 })
+
+/*
+function getDependenciesFromPackageFiles (packagePaths, packageJsonContents) {
+*/
+
+const { getDependenciesFromPackageFiles } = require('../../utils/initial-branch-utils')
+describe('initial branch utils', () => {
+  test('getDependenciesFromPackageFiles single devDependency', () => {
+    const paths = [
+      'foobar/package.json'
+    ]
+    const contents = { 'foobar/package.json': { devDependencies: { '@finnpauls/dep': '1.0.0' } } }
+    const result = getDependenciesFromPackageFiles(paths, contents)
+    expect(result).toMatchSnapshot()
+  })
+
+  test('getDependenciesFromPackageFiles duplicate dependency across dep type', () => {
+    const paths = [
+      'foobar/package.json',
+      'bazquux/package.json'
+    ]
+    const contents = {
+      'foobar/package.json': { devDependencies: { '@finnpauls/dep': '1.0.0' } },
+      'bazquux/package.json': { devDependencies: { '@finnpauls/dep': '1.0.0' } }
+    }
+    const result = getDependenciesFromPackageFiles(paths, contents)
+    expect(result).toMatchSnapshot()
+  })
+
+  test('getDependenciesFromPackageFiles workspace', () => {
+    const paths = [
+      'package.json',
+      'bazquux/package.json'
+    ]
+    const contents = {
+      'package.json': { devDependencies: { '@finnpauls/blup': '1.0.0' }, workspaceRoot: 'bazquux/' },
+      'bazquux/package.json': { devDependencies: { '@finnpauls/dep': '*' }, dependencies: { 'florp': '1.2.3' } }
+    }
+    const result = getDependenciesFromPackageFiles(paths, contents)
+    expect(result).toMatchSnapshot()
+  })
+})


### PR DESCRIPTION
yarn monorepos are identified by packageJson.workspaceRoot.
if we are handling one of those, we might encounter a [sub-]
package.json that specifies a dependency like this:
"@reponame/dependency": "*" which looks like a scoped npm
dependency, but is in reality a in-monorepo dependency.
For those dependencies, we should not try to fetch infos
from npm, because the dependencies are not there.