### PR TITLE
fix(createBranch): update yarn lockfile for non-workspaces

### DIFF
--- a/lib/create-branch.js
+++ b/lib/create-branch.js
@@ -92,7 +92,7 @@ const createLockfileCommits = async ({ commits, repoDoc, installationId, commitM
     if (!commit.path.includes('package.json')) continue
     const packageJsonPath = commit.path
     const lockfilePath = getLockfilePath(repoDoc.files, packageJsonPath)
-    if (isYarn) {
+    if (isYarn && packageJsonPathsWithWorkspaceDefinitions.length !== 0) {
       // Iterate though all workspace definitions until we find a workspace path/glob that fits our commit.path
       const workspaceRootPath = getWorkspaceRootPathForCommit({
         workspaceRootPaths: packageJsonPathsWithWorkspaceDefinitions,

--- a/test/lib/create-branch/__snapshots__/create-branch.js.snap
+++ b/test/lib/create-branch/__snapshots__/create-branch.js.snap
@@ -9,6 +9,15 @@ Object {
 }
 `;
 
+exports[`create branch with lockfiles change one file (package.json) and generate its lockfile (yarn) 1`] = `
+Object {
+  "lock": "{\\"devDependencies\\":{\\"jest\\":\\"1.1.1\\"}}",
+  "packageJson": "{\\"devDependencies\\":{\\"jest\\":\\"1.2.0\\"}}",
+  "repositoryTokens": "",
+  "type": "yarn",
+}
+`;
+
 exports[`create branch with lockfiles change one file (package.json) and generate its lockfile 1`] = `
 Object {
   "lock": "{\\"devDependencies\\":{\\"jest\\":\\"1.1.1\\"}}",


### PR DESCRIPTION
When trying to add support for yarn workspaces, we caught the non-workspaces in the same loop. So we missed updating them.